### PR TITLE
Adds a method to create a hard link too.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ flycheck_*.el
 
 .idea/
 gh-pages/
+
+# lsp
+.lsp/

--- a/src/babashka/fs.cljc
+++ b/src/babashka/fs.cljc
@@ -377,6 +377,13 @@
    (as-path target)
    (make-array FileAttribute 0)))
 
+(defn create-link
+  "Create a hard link from path to target."
+  [path target]
+  (Files/createLink
+  (as-path path)
+  (as-path target)))
+
 (defn delete
   "Deletes f. Returns nil if the delete was successful,
   throws otherwise. Does not follow symlinks."

--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -43,12 +43,12 @@
                    (set (map str
                              (fs/glob "." "**.{clj,cljc}")))))
   (testing "glob also matches directories and doesn't return the root directory"
-    (is (= '("test-resources/foo/1" "test-resources/foo/foo")
-           (map str
-                (fs/glob "test-resources/foo" "**"))))
-    (is (= '("test-resources/foo/1" "test-resources/foo/foo")
-           (map str
-                (fs/glob "test-resources" "foo/**")))))
+    (is (set/subset? #{"test-resources/foo/1" "test-resources/foo/foo"}
+                     (set (map str
+                               (fs/glob "test-resources/foo" "**")))))
+    (is (set/subset? #{"test-resources/foo/1" "test-resources/foo/foo"}
+                     (set (map str
+                               (fs/glob "test-resources" "foo/**"))))))
   (testing "symlink as root path"
     (let [tmp-dir1 (temp-dir)
           _ (spit (fs/file tmp-dir1 "dude.txt") "contents")
@@ -66,6 +66,16 @@
 
 (deftest create-dir-test
   (is (fs/create-dir (fs/path (temp-dir) "foo"))))
+
+(deftest create-link-test
+  (let [tmp-dir (temp-dir)
+        _ (spit (fs/file tmp-dir "dudette.txt") "some content")
+        link (fs/create-link (fs/file tmp-dir "hard-link.txt") (fs/file tmp-dir "dudette.txt"))]
+    (is (.exists (io/as-file link)))
+    (is (.exists (fs/file tmp-dir "dudette.txt")))
+    (is (= (slurp (fs/file tmp-dir "hard-link.txt"))
+           (slurp (fs/file tmp-dir "dudette.txt"))))))
+
 
 (deftest parent-test
   (let [tmp-dir (temp-dir)]


### PR DESCRIPTION
I have a need to do the equivalent of `cp -al` (copy a tree, preserving attributes, but use hard links). 

I know this method alone won't do it, but I made the change as a first step, just to get my head around the repo and tests. I thought might it might be useful in of itself?

I also changed one of the existing tests, because the files were coming back in the reverse order for me. Might be related to running on Ubuntu, so I thought changing it so that the order doesn't matter, might be an improvement? Feel free to ignore.