### PR TITLE
Update tests to work in more environments

### DIFF
--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -6,8 +6,6 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]))
 
-(def cwd (fs/real-path "."))
-
 (defn temp-dir []
   (-> (fs/create-temp-dir)
       (fs/delete-on-exit)))
@@ -69,10 +67,10 @@
 
 (deftest create-link-test
   (let [tmp-dir (temp-dir)
-        _ (spit (fs/file tmp-dir "dudette.txt") "some content")
-        link (fs/create-link (fs/file tmp-dir "hard-link.txt") (fs/file tmp-dir "dudette.txt"))]
-    (is (.exists (io/as-file link)))
-    (is (= 2 (fs/get-attribute (io/as-file link) "unix:nlink")))
+        _       (spit (fs/file tmp-dir "dudette.txt") "some content")
+        link    (fs/create-link (fs/file tmp-dir "hard-link.txt") (fs/file tmp-dir "dudette.txt"))]
+    (is (.exists (fs/file link)))
+    (is (= 2 (fs/get-attribute (fs/file link) "unix:nlink")))
     (is (.exists (fs/file tmp-dir "dudette.txt")))
     (is (fs/same-file? (fs/file tmp-dir "dudette.txt")
                        (fs/file tmp-dir "hard-link.txt")))
@@ -87,9 +85,11 @@
             (= tmp-dir)))))
 
 (deftest file-name-test
-  (is (= "fs" (fs/file-name cwd)))
-  (is (= "fs" (fs/file-name (fs/file cwd))))
-  (is (= "fs" (fs/file-name (fs/path cwd)))))
+  (let [tmp-dir (fs/path (temp-dir) "foo")]
+    (fs/create-dir tmp-dir)
+    (is (= "foo" (fs/file-name tmp-dir)))
+    (is (= "foo" (fs/file-name (fs/file tmp-dir))))
+    (is (= "foo" (fs/file-name (fs/path tmp-dir))))))
 
 (deftest path-test
   (let [p (fs/path "foo" "bar" (io/file "baz"))]
@@ -117,8 +117,8 @@
       (is (= cur-dir-count tmp-dir-count)))))
 
 (deftest components-test
-  (let [paths (map str (fs/components (fs/real-path ".")))]
-    (is (= "fs" (last paths)))
+  (let [paths (map str (fs/components (fs/path (temp-dir) "foo")))]
+    (is (= "foo" (last paths)))
     (is (> (count paths) 1))))
 
 (deftest list-dir-test


### PR DESCRIPTION
fs-test: update tests to be independent of cwd
fs-test: use fs/file instead of io/as-file, since it breaks on UnixPath

---

Having pulled down this repo into a folder called 'babashka-fs', I found that some of the tests depend on the name of the repo folder to work -- I swapped those to use directories in `temp-dir`.

Also, I found `io/as-file` was broken when operating on the output of `fs/create-link`, so I switched it to `fs/file` which can coerce from `Path`.