### PR TITLE
fs: add regular-file? predicate

### DIFF
--- a/src/babashka/fs.cljc
+++ b/src/babashka/fs.cljc
@@ -71,6 +71,13 @@
 
 ;;;; Predicates
 
+(defn regular-file?
+  "Returns true if f is a regular file, using Files/isRegularFile."
+  ([f] (regular-file? f nil))
+  ([f {:keys [:nofollow-links]}]
+   (Files/isRegularFile (as-path f)
+                        (->link-opts nofollow-links))))
+
 (defn directory?
   "Returns true if f is a directory, using Files/isDirectory."
   ([f] (directory? f nil))

--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -79,6 +79,12 @@
     (is (= (slurp (fs/file tmp-dir "hard-link.txt"))
            (slurp (fs/file tmp-dir "dudette.txt"))))))
 
+(deftest regular-file?-test
+  (let [tmp-dir  (temp-dir)
+        tmp-file (fs/path tmp-dir "tmp.txt")]
+    (spit (fs/file tmp-file) "")
+    (is (not (fs/regular-file? tmp-dir)))
+    (is (fs/regular-file? tmp-file))))
 
 (deftest parent-test
   (let [tmp-dir (temp-dir)]


### PR DESCRIPTION
There are predicates for `directory?` and `sym-link?`, but none for `file?`.

To highlight that it's the `Files/isRegularFile` check underlying it, I called the predicate `regular-file?`, although I suspect `file?` would probably be fine for most folks' understanding?