### PR TITLE
nate/fs -> corasaurus-hex/fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ that.
 The main inspirations for this library are
 [clojure.java.io](https://clojure.github.io/clojure/clojure.java.io-api.html),
 [clj-commons/fs](https://github.com/clj-commons/fs) and
-[nate/fs](https://github.com/nate/fs/blob/master/src/nate/fs.clj).
+[corasaurus-hex/fs](https://github.com/corasaurus-hex/fs/blob/master/src/corasaurus-hex/fs.clj).
 
 ## API docs
 


### PR DESCRIPTION
Account changed! There's a redirect in place but probably better to just directly link.