### PR TITLE
nate/fs -> corasaurus-hex/fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ that.
 The main inspirations for this library are
 [clojure.java.io](https://clojure.github.io/clojure/clojure.java.io-api.html),
 [clj-commons/fs](https://github.com/clj-commons/fs) and
-[nate/fs](https://github.com/nate/fs/blob/master/src/nate/fs.clj).
+[corasaurus-hex/fs](https://github.com/corasaurus-hex/fs/blob/master/src/corasaurus_hex/fs.clj).
 
 ## API docs
 

--- a/src/babashka/fs.cljc
+++ b/src/babashka/fs.cljc
@@ -533,7 +533,7 @@
   [f]
   (vec (Files/readAllLines (as-path f))))
 
-;;;; Attributes, from github.com/nate/fs
+;;;; Attributes, from github.com/corasaurus-hex/fs
 
 (defn get-attribute
   ([path attribute]


### PR DESCRIPTION
Username changed! There's a redirect in place from nate/fs to
corasaurus-hex/fs but probably better to just directly link.

Thanks!