### PR TITLE
Add `fs/home` and `fs/expand-home`

### DIFF
--- a/src/babashka/fs.cljc
+++ b/src/babashka/fs.cljc
@@ -815,3 +815,31 @@
        ~@body
        (finally
          (delete-tree ~binding-name)))))
+
+(let [homedir (path (System/getProperty "user.home"))
+      usersdir (parent homedir)]
+  (defn ^Path home
+    "With no arguments, returns the current value of the `user.home` system
+     property. If a `user` is passed, returns that user's home directory. It
+     is naively assumed to be a directory with the same name as the `user`
+     located relative to the parent of the current value of `user.home`."
+    ([] homedir)
+    ([user] (if (empty? user) homedir (path usersdir user)))))
+
+
+(defn ^Path expand-home
+  "If `path` begins with a tilde (`~`), expand the tilde to the value
+  of the `user.home` system property. If the `path` begins with a
+  tilde immediately followed by some characters, they are assumed to
+  be a username. This is expanded to the path to that user's home
+  directory. This is (naively) assumed to be a directory with the same
+  name as the user relative to the parent of the current value of
+  `user.home`."
+  [f]
+  (let [path-str (str f)]
+    (if (.startsWith path-str "~")
+      (let [sep (.indexOf path-str File/separator)]
+        (if (neg? sep)
+          (home (subs path-str 1))
+          (path (home (subs path-str 1 sep)) (subs path-str (inc sep)))))
+      (as-path f))))

--- a/src/babashka/fs.cljc
+++ b/src/babashka/fs.cljc
@@ -816,15 +816,15 @@
        (finally
          (delete-tree ~binding-name)))))
 
-(let [homedir (path (System/getProperty "user.home"))
-      usersdir (parent homedir)]
+(let [homedir (delay (path (System/getProperty "user.home")))
+      usersdir (delay (parent @homedir))]
   (defn ^Path home
     "With no arguments, returns the current value of the `user.home` system
      property. If a `user` is passed, returns that user's home directory. It
      is naively assumed to be a directory with the same name as the `user`
      located relative to the parent of the current value of `user.home`."
-    ([] homedir)
-    ([user] (if (empty? user) homedir (path usersdir user)))))
+    ([] @homedir)
+    ([user] (if (empty? user) @homedir (path @usersdir user)))))
 
 
 (defn ^Path expand-home

--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -450,7 +450,8 @@
   (testing "for the current user"
     (is (= (fs/home)
            (fs/expand-home (fs/path "~"))
-           (fs/expand-home "~")))
+           (fs/expand-home "~")
+           (fs/expand-home (str "~" fs/file-separator))))
     (is (= (fs/path (fs/home) "abc" "bb")
            (fs/expand-home (fs/path "~" "abc" "bb"))))
     ; Weird but technically allowed

--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -447,6 +447,7 @@
              (fs/home nil))))))
 
 (deftest expand-home-test
+  ; The following tests assume that fs/home is working correctly
   (testing "for the current user"
     (is (= (fs/home)
            (fs/expand-home (fs/path "~"))

--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -431,3 +431,33 @@
       (testing "deletes its directory and contents on exit from the scope"
         (is (not (fs/exists? (fs/path @capture-dir "xx"))))
         (is (not (fs/exists? @capture-dir)))))))
+
+(deftest home-test
+  (let [user-home (fs/path (System/getProperty "user.home"))
+        user-dir (fs/parent user-home)]
+    (testing "without arguments"
+      (is (= user-home
+             (fs/home))))
+    (testing "with a username"
+      (is (= (fs/path user-dir "this-is-me")
+             (fs/home "this-is-me"))))
+    (testing "without username"
+      (is (= user-home
+             (fs/home "")
+             (fs/home nil))))))
+
+(deftest expand-home-test
+  (testing "for the current user"
+    (is (= (fs/home)
+           (fs/expand-home (fs/path "~"))
+           (fs/expand-home "~")))
+    (is (= (fs/path (fs/home) "abc" "bb")
+           (fs/expand-home (fs/path "~" "abc" "bb"))))
+    ; Weird but technically allowed
+    (is (= (fs/path (fs/home) "..")
+           (fs/expand-home (fs/path "~" ".."))))
+    (is (= (fs/path (fs/home) ".")
+           (fs/expand-home (fs/path "~" ".")))))
+  (testing "for another user")
+  (testing "without nothing to expand")
+  (testing "with ~ in another place"))

--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -458,6 +458,14 @@
            (fs/expand-home (fs/path "~" ".."))))
     (is (= (fs/path (fs/home) ".")
            (fs/expand-home (fs/path "~" ".")))))
-  (testing "for another user")
-  (testing "without nothing to expand")
+  (testing "for another user"
+    (is (= (fs/home "lola")
+           (fs/expand-home (fs/path "~lola"))
+           (fs/expand-home "~lola")
+           (fs/expand-home (str "~lola" fs/file-separator))))
+    (is (= (fs/path (fs/home "lola") "has" "a" "file")
+           (fs/expand-home (fs/path "~lola" "has" "a" "file"))
+           (fs/expand-home (str/join fs/file-separator ["~lola" "has" "a" "file"])))))
+  (testing "without nothing to expand"
+    ())
   (testing "with ~ in another place"))

--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -487,3 +487,5 @@
                    ["a~" "b" "c"]]]
       (is (= (apply fs/path input)
              (fs/expand-home (str/join fs/file-separator input))))))
+  (is (= (fs/path (fs/home) "abc" "~" "def")
+           (fs/expand-home (fs/path "~" "abc" "~" "def")))))

--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -466,7 +466,24 @@
            (fs/expand-home (str "~lola" fs/file-separator))))
     (is (= (fs/path (fs/home "lola") "has" "a" "file")
            (fs/expand-home (fs/path "~lola" "has" "a" "file"))
-           (fs/expand-home (str/join fs/file-separator ["~lola" "has" "a" "file"])))))
+           (fs/expand-home (str/join fs/file-separator ["~lola" "has" "a" "file"]))))
+    ; Weird but technically allowed
+    (is (= (fs/path (fs/home "raymond") "..")
+           (fs/expand-home (fs/path "~raymond" ".."))))
+    (is (= (fs/path (fs/home "raymond") ".")
+           (fs/expand-home (fs/path "~raymond" ".")))))
   (testing "without nothing to expand"
-    ())
-  (testing "with ~ in another place"))
+    (doseq [input [["a" "b" "c"]
+                   [""]
+                   ["."]
+                   [".."]]]
+      (is (= (apply fs/path input)
+             (fs/expand-home (str/join fs/file-separator input))))))
+  (testing "with ~ in another place"
+    (doseq [input [["a" "b" "~"]
+                   ["a" "b" "~c"]
+                   ["a" "~" "c"]
+                   ["a" "~b" "c"]
+                   ["a~" "b" "c"]]]
+      (is (= (apply fs/path input)
+             (fs/expand-home (str/join fs/file-separator input))))))


### PR DESCRIPTION
The code implementing the two functions is taken from _clj-commons/fs_, with some minor changes to adapt it to the paradigm of babashka/fs.

Find the value for the user home is a task left to the JVM, via the API `System.getProperty("user.home")`.
From tests in linux, it returns a logical result. Strangely, when tested with a system user without a home directory, it still returned "/home/<username>". But this being a behaviour that must be strongly specified in the JVM, I decided not to challenge it.

I wrote a series of tests, covering standard cases and some weird cases I thought about.
I also checked the tests from _clj-commons/fs_ [2] and [3] but they are more succinct and included in the current tests.

[1] https://github.com/clj-commons/fs
[2] home tests: https://github.com/clj-commons/fs/blob/04c7b1abcc2f3cdff782dae7f022781aed11c42a/test/me/raynes/core_test.clj#L249-L254
[3] expand-home tests: https://github.com/clj-commons/fs/blob/04c7b1abcc2f3cdff782dae7f022781aed11c42a/test/me/raynes/core_test.clj#L27-L40

Fixes #12
Fixes #13 