### PR TITLE
changes to 'which' function to more closely mimic unix 'which'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 For a list of breaking changes, check [here](#breaking-changes).
 
+## Unreleased
+
+- [#51](https://github.com/babashka/fs/issues/51): Update `which` function to more closely mimic unix `which`:
+  - do not identify directories as matches
+  - if the argument is a relative path (more than just a file/command name), then don't search path entries
+
 ## v0.1.4
 
 - Add `windows?` predicate

--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -282,7 +282,7 @@
     ;; on Windows we can find the executable on the path without the .exe extension
     (is (= java (fs/which "java")))
     (is (contains? (set (fs/which-all "java")) java))
-    (fs/create-dirs "on-path")
+    (fs/create-dirs "on-path/path-subdir")
     (if windows?
       (doto (fs/file "on-path" "foo.foo.bat")
         (spit "echo hello"))
@@ -297,6 +297,10 @@
       (testing "can find foo.cmd.bat"
         (spit "on-path/foo.cmd.bat" "echo hello")
         (is (= (fs/which "foo.cmd") (fs/which "foo.cmd.bat")))))
+    (testing "'which' shouldn't find directories"
+      (is (nil? (fs/which "path-subdir"))))
+    (testing "given a relative path, 'which' shouldn't search path entries"
+      (is (nil? (fs/which "./foo.foo"))))
     (fs/delete-tree "on-path")))
 
 (deftest predicate-test


### PR DESCRIPTION
closes #51 

- don't match directories (only affects non-Windows environments):

before:
```
~$ bb "(require '[babashka.fs :as fs]) (fs/which \"Scripts\")"
#object[sun.nio.fs.UnixPath 0x3cd9d370 "/mnt/c/Python38/Scripts"]
~$ /mnt/c/Python38/Scripts
-bash: /mnt/c/Python38/Scripts: Is a directory
```
after:
```
$ ./bb "(require '[babashka.fs :as fs]) (println (fs/which \"Scripts\"))"
nil
```

- don't search $PATH entries when given a relative path (affects Windows and non-Windows):

Windows output
before:
```
C:\some\directory>bb "(require '[babashka.fs :as fs]) (fs/which \"npm\")"
#object[sun.nio.fs.WindowsPath 0x4d2e63a9 "C:\\Users\\...\\npm.cmd"]

C:\some\directory>bb "(require '[babashka.fs :as fs]) (fs/which \"./npm\")"
#object[sun.nio.fs.WindowsPath 0x1e02ca7a "C:\\Users\\...\\.\\npm.cmd"]
```

after:
```
C:\some\directory>bb "(require '[babashka.fs :as fs]) (fs/which \"npm\")"
#object[sun.nio.fs.WindowsPath 0x5b90f5ff "C:\\Users\\...\\npm.cmd"]

C:\some\directory>bb "(require '[babashka.fs :as fs]) (fs/which \"./npm\")"
(no output)
```