### PR TITLE
Fix escaping so the example is valid

### DIFF
--- a/src/babashka/fs.cljc
+++ b/src/babashka/fs.cljc
@@ -253,7 +253,7 @@
   - :max-depth: max depth to descend into directory structure.
 
   Examples:
-  (fs/match \".\" \"regex:.*\\.clj\" {:recursive true})"
+  (fs/match \".\" \"regex:.*\\\\.clj\" {:recursive true})"
   ([root pattern] (match root pattern nil))
   ([root pattern {:keys [hidden follow-links max-depth recursive]}]
    (let [base-path (-> root absolutize normalize)


### PR DESCRIPTION
Currently the doc string for `match` prints like this: 

``` 
  Examples:
  (fs/match "." "regex:.*\.clj" {:recursive true})
```
The small issue is that there is one \ to few and if you copy this it is not a valid call.
Solution: 
Add 1 more \ so that the example can be copied from the doc.