### PR TITLE
Expose `:win-exts` option for `which` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For convenience, the above use case is also supported using the `which` function
 ## Test
 
 ``` clojure
-$ clojure -M:test
+$ bb test
 ```
 
 <!-- ## Codox -->

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,8 @@ clone_script:
 
 build_script:
 - cmd: >-
-    powershell -Command "if (Test-Path('bb.exe')) { return } else { (New-Object Net.WebClient).DownloadFile('https://github.com/borkdude/babashka/releases/download/v0.6.5/babashka-0.6.5-windows-amd64.zip', 'bb.zip') }"
+
+    powershell -Command "if (Test-Path('bb.exe')) { return } else { (New-Object Net.WebClient).DownloadFile('https://github.com/babashka/babashka/releases/download/v0.9.161/babashka-0.9.161-windows-amd64.zip', 'bb.zip') }"
 
     powershell -Command "if (Test-Path('bb.exe')) { return } else { Expand-Archive bb.zip . }"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,4 @@ build_script:
 
     powershell -Command "if (Test-Path('bb.exe')) { return } else { Expand-Archive bb.zip . }"
 
-    set PATH=on-path;%PATH%;
-
     call bb test

--- a/bb.edn
+++ b/bb.edn
@@ -6,11 +6,8 @@
  :tasks
  {:requires ([babashka.fs :as fs]
              [clojure.string :as str])
-  test (let [windows? (-> (System/getProperty "os.name")
-                          (str/lower-case)
-                          (str/includes? "win"))]
-         (clojure {:extra-env {(if windows? "Path" "PATH") (str "on-path" fs/path-separator (System/getenv "PATH"))}}
-                  "-M:test"))
+  test (clojure {:extra-env {(if (fs/windows?) "Path" "PATH") (str "on-path" fs/path-separator (System/getenv "PATH"))}}
+                "-M:test")
 
   quickdoc {:doc "Invoke quickdoc"
             :requires ([quickdoc.api :as api])

--- a/bb.edn
+++ b/bb.edn
@@ -1,4 +1,5 @@
-{:pods {clj-kondo/clj-kondo {:version "2022.02.09"}}
+{:min-bb-version "0.9.161"
+ :pods {clj-kondo/clj-kondo {:version "2022.02.09"}}
  :deps {io.github.borkdude/quickdoc
         #_{:local/root "/Users/borkdude/dev/quickdoc"}
         {:git/sha "ca5893c0d81f26443dd178a747d0851e75d39eca"}}

--- a/bb.edn
+++ b/bb.edn
@@ -4,9 +4,13 @@
         {:git/sha "ca5893c0d81f26443dd178a747d0851e75d39eca"}}
 
  :tasks
- {:requires ([babashka.fs :as fs])
-  test (clojure {:extra-env {"PATH" (str "on-path" fs/path-separator (System/getenv "PATH"))}}
-                "-M:test")
+ {:requires ([babashka.fs :as fs]
+             [clojure.string :as str])
+  test (let [windows? (-> (System/getProperty "os.name")
+                          (str/lower-case)
+                          (str/includes? "win"))]
+         (clojure {:extra-env {(if windows? "Path" "PATH") (str "on-path" fs/path-separator (System/getenv "PATH"))}}
+                  "-M:test"))
 
   quickdoc {:doc "Invoke quickdoc"
             :requires ([quickdoc.api :as api])

--- a/src/babashka/fs.cljc
+++ b/src/babashka/fs.cljc
@@ -779,13 +779,13 @@
     (= f-as-path (.getFileName f-as-path))))
 
 (defn which
-  "Locates a program in (exec-paths) similar to the which Unix command.
-  On Windows it tries to resolve in the order of: .com, .exe, .bat,
-  .cmd."
+  "Returns Path to first `program` found in (`exec-paths`), similar to the which Unix command.
+
+  On Windows, also searches for `program` with filename extensions specified in `:win-exts` `opt`.
+  Default is `[\"com\" \"exe\" \"bat\" \"cmd\"]`.
+  If `program` already includes an extension from `:win-exts`, it will be searched as-is first."
   ([program] (which program nil))
   ([program opts]
-   ;; :win-exts is unsupported, if you read and use
-   ;; this, let me know, it may break.
    (let [exts (if win?
                 (let [exts (or (:win-exts opts)
                                ["com" "exe" "bat" "cmd"])
@@ -824,6 +824,7 @@
          (if (:all opts) results (first results)))))))
 
 (defn which-all
+  "Returns every Path to `program` found in (`exec-paths`). See `which`."
   ([program] (which-all program nil))
   ([program opts]
    (which program (assoc opts :all true))))


### PR DESCRIPTION
Update docstrings for `which` and `which-all`.

Notice `which` tests are not passing on Windows
- Update test launch instruction in README to invoke existing bb `test`
task. This setup updates PATH for `which` tests.
- Address setup issue: environment var name must be `Path` for Windows.

Add Windows only test that exercises `:win-exts`.
Update some existing `which` tests to be more explicit in their expectations.

Closes #65