### PR TITLE
exists? should never throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ For a list of breaking changes, check [here](#breaking-changes).
 ## Unreleased
 
 - [#65](https://github.com/babashka/fs/issues/65): Explicitly support `:win-exts` option on `which` function ([@lread](https://github.com/lread))
+- [clj-kondo#1782](https://github.com/clj-kondo/clj-kondo/issues/1782): `exists?` should never throw on illegal input path.
 
 ## v0.1.6
 

--- a/src/babashka/fs.cljc
+++ b/src/babashka/fs.cljc
@@ -125,9 +125,12 @@
   "Returns true if f exists."
   ([f] (exists? f nil))
   ([f {:keys [:nofollow-links]}]
-   (Files/exists
-    (as-path f)
-    (->link-opts nofollow-links))))
+   (try
+     (Files/exists
+      (as-path f)
+      (->link-opts nofollow-links))
+     (catch Exception _e
+       false))))
 
 ;;;; End predicates
 

--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -549,3 +549,9 @@
 (deftest uri->path-test
   (is (instance? java.nio.file.Path
                  (fs/path (.toURI (fs/file "."))))))
+
+(deftest invalid-path
+  (testing "illegal windows path"
+    ;; a `:` outside of the drive letter is illegal but should not
+    ;; throw.
+    (is (= (fs/exists? "c:/123:456") false))))


### PR DESCRIPTION
Hi,

could you please consider patch to fix an issue encountered with https://github.com/clj-kondo/clj-kondo/issues/1782 that an illegal path on MS-Windows can cause `exists?` to throw. 

It has been agreed that this function should never throw, but return nil if the path doe snot point to real element.

Thanks