### PR TITLE
chore(docs): update docs for glob, it returns paths instead of files

### DIFF
--- a/API.md
+++ b/API.md
@@ -32,7 +32,7 @@
     -  [`file-time->instant`](#babashka.fs/file-time->instant) - Converts a java.nio.file.attribute.FileTime to a java.time.Instant.
     -  [`file-time->millis`](#babashka.fs/file-time->millis) - Converts a java.nio.file.attribute.FileTime to epoch millis (long).
     -  [`get-attribute`](#babashka.fs/get-attribute)
-    -  [`glob`](#babashka.fs/glob) - Given a file and glob pattern, returns matches as vector of files.
+    -  [`glob`](#babashka.fs/glob) - Given a file and glob pattern, returns matches as vector of paths.
     -  [`hidden?`](#babashka.fs/hidden?) - Returns true if f is hidden.
     -  [`home`](#babashka.fs/home) - With no arguments, returns the current value of the <code>user.home</code> system property.
     -  [`instant->file-time`](#babashka.fs/instant->file-time) - Converts a java.time.Instant to a java.nio.file.attribute.FileTime.
@@ -458,7 +458,7 @@ Converts a java.nio.file.attribute.FileTime to epoch millis (long).
 
 
 Given a file and glob pattern, returns matches as vector of
-  files. Patterns containing `**` or `/` will cause a recursive walk over
+  paths. Patterns containing `**` or `/` will cause a recursive walk over
   path, unless overriden with :recursive. Glob interpretation is done
   using the rules described in
   https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Babashka [fs](https://github.com/babashka/fs): file system utility library for C
 ## Unreleased
 
 - [#81](https://github.com/babashka/fs/issues/81): do not process directories in `strip-ext` and `split-ext`
+- Correct documentation for match/glob functions return value [@thenonameguy](https://github.com/thenonameguy)
 
 ## v0.2.12 (2022-11-16)
 

--- a/src/babashka/fs.cljc
+++ b/src/babashka/fs.cljc
@@ -246,12 +246,12 @@
 
 (defn match
   "Given a file and match pattern, returns matches as vector of
-  files. Pattern interpretation is done using the rules described in
+  paths. Pattern interpretation is done using the rules described in
   https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String).
 
   Options:
 
-  * `:hidden:` match hidden files - note: on Windows files starting with
+  * `:hidden:` match hidden paths - note: on Windows paths starting with
   a dot are not hidden, unless their hidden attribute is set.
   * `:follow-links:` - follow symlinks
   * `:recursive:` - match recursively.
@@ -312,14 +312,14 @@
 
 (defn glob
   "Given a file and glob pattern, returns matches as vector of
-  files. Patterns containing `**` or `/` will cause a recursive walk over
+  paths. Patterns containing `**` or `/` will cause a recursive walk over
   path, unless overriden with :recursive. Glob interpretation is done
   using the rules described in
   https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String).
 
   Options:
 
-  * `:hidden:` match hidden files. Note: on Windows files starting with
+  * `:hidden:` match hidden paths. Note: on Windows files starting with
   a dot are not hidden, unless their hidden attribute is set.
   * `:follow-links:` follow symlinks.
   * `:recursive:` force recursive search.

--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -43,7 +43,9 @@
        (fs/walk-file-tree "." {:pre-visit-dir (fn [_ _])}))))
 
 (deftest match-test
-  (is (= '("README.md") (map str (fs/match "." "regex:README.md"))))
+  (let [readme-match (fs/match "." "regex:README.md")]
+    (is (= '("README.md") (map str readme-match)))
+    (is (every? #(instance? java.nio.file.Path %) readme-match)))
   (is (set/subset? #{"project.clj"
                      "test/babashka/fs_test.clj"
                      "src/babashka/fs.cljc"}
@@ -75,8 +77,9 @@
                         (fs/match tmp-dir1 "regex:foo/bar/baz/.*" {:recursive true}))))))))
 
 (deftest glob-test
-  (is (= '("README.md") (map str
-                             (fs/glob "." "README.md"))))
+  (let [readme-match (fs/glob "." "README.md")]
+    (is (= '("README.md") (map str readme-match)))
+    (is (every? #(instance? java.nio.file.Path %) readme-match)))
   (is (set/subset? #{"project.clj"
                      "test/babashka/fs_test.clj"
                      "src/babashka/fs.cljc"}


### PR DESCRIPTION
Proof:
```
user=> (into #{} (map type) (babashka.fs/glob "." "*"))
#{sun.nio.fs.UnixPath}
```

Please answer the following questions and leave the below in as part of your PR.

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/fs/blob/master/CHANGELOG.md) file with a description of the addressed issue.
