### PR TITLE
`which` updates: `:paths` and absolute `program`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Babashka [fs](https://github.com/babashka/fs): file system utility library for C
 ## Unreleased
 
 - [#91](https://github.com/babashka/fs/issues/91): add 1-arity to `xdg-*-home` to get subfolder of base directory ([@eval](https://github.com/eval))
+- [#94](https://github.com/babashka/fs/issues/94): updates to `which`: add `:paths` `opt`, allow absolute paths for `program` ([@lread](https://github.com/lread))
 
 ## v0.3.17 (2023-02-28)
 


### PR DESCRIPTION
New `:paths` `opt` can be used to specify custom search paths. Default remains `(exec-paths)`

The `program` argument can now specify an absolute path.

Docstring updated and includes description of existing relative path support for `program` argument.

Relative and absolute path support for `program` make cross-platform support more convenient. For example `(fs/which ./myapp)` will find `./myapp` on macos/linux and `./myapp.exe` on Windows.

Closes #94

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/fs/blob/master/CHANGELOG.md) file with a description of the addressed issue.
