### PR TITLE
Add more robust tests for owner fn (#97)

### DIFF
--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -711,8 +711,12 @@
            (fs/xdg-state-home "clj-kondo")))))
 
 (deftest file-owner-test
+  (testing "Java process owner is the same as the home path owner"
+    (let [path (fs/home)
+          process-owner (System/getProperty "user.name")]
+      (is (= (str (fs/owner path)) process-owner))))
+  
   (testing "works for files as well"
-    (let [dir (doto (fs/create-temp-dir)
-                fs/delete-on-exit)
-          file-in-dir (fs/create-temp-file {:dir dir})]
-      (is (= (str (fs/owner dir)) (str (fs/owner file-in-dir)))))))
+    (let [file (fs/create-file (fs/path (temp-dir) "file-owner-test")) 
+          process-owner (System/getProperty "user.name")]
+      (is (= (str (fs/owner file)) process-owner)))))


### PR DESCRIPTION
Use JVM system property user.name to figure out who the process owner
is, then compare that to both the owner of the home directory and a
temporary file created in process, which both should be the process
owner.

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/babashka/fs/blob/master/CHANGELOG.md) file with a description of the addressed issue.
