### PR TITLE
find-up

### DIFF
--- a/API.md
+++ b/API.md
@@ -31,7 +31,7 @@
     -  [`file-separator`](#babashka.fs/file-separator)
     -  [`file-time->instant`](#babashka.fs/file-time->instant) - Converts a java.nio.file.attribute.FileTime to a java.time.Instant.
     -  [`file-time->millis`](#babashka.fs/file-time->millis) - Converts a java.nio.file.attribute.FileTime to epoch millis (long).
-    -  [`find-up`](#babashka.fs/find-up) - Starting in folder <code>start</code> and traversing up, either checks if the folder contains <code>to-find</code> (returning the path if it does) or, when <code>to-find</code> is an fn, returns the path of the first folder for which <code>to-find</code> returns logical true.
+    -  [`find-up`](#babashka.fs/find-up) - Starting in <code>start</code> and traversing up, checks if the folder contains <code>file</code>.
     -  [`get-attribute`](#babashka.fs/get-attribute)
     -  [`glob`](#babashka.fs/glob) - Given a file and glob pattern, returns matches as vector of paths.
     -  [`gunzip`](#babashka.fs/gunzip) - Extracts <code>gz-file</code> to <code>dest</code> directory (default <code>"."</code>).
@@ -424,47 +424,30 @@ Converts a java.nio.file.attribute.FileTime to epoch millis (long).
 ## <a name="babashka.fs/find-up">`find-up`</a><a name="babashka.fs/find-up"></a>
 ``` clojure
 
-(find-up to-find)
-(find-up to-find start)
+(find-up file)
+(find-up start file)
 ```
 
-Starting in folder `start` and traversing up, either checks if the folder contains `to-find` (returning the path if it does) or, when `to-find` is an fn, returns the path of the first folder for which `to-find` returns logical true.
+Starting in `start` and traversing up, checks if the folder contains [[`file`](#babashka.fs/file)](#babashka.fs/file).
 
-  - `to-find` - a string, file or path such as "README.md", ".", (fs/path "fs") or a (fn accept [^java.nio.file.Path p]) -> truthy.
-  - `start` (default `(fs/cwd)`) - a string, file or path such as ".", "~/projects", (fs/file "README.md"). This folder or file should exist, else an `IllegalArgumentException` is thrown.
+  - `start` (default `(fs/cwd)`) - a string, file or path such as ".", (fs/file "README.md").
+  - [[`file`](#babashka.fs/file)](#babashka.fs/file) - a string, file or path such as "README.md", ".", (fs/path "fs").
 
-  Yields the path found, else `nil`.
+  Yields the path of the file found, else `nil`.
 
   Examples:
 
   ``` clojure
   (fs/find-up "README.md") ;; search for README.md starting from CWD.
 
-  ;; find .gitignore starting from parent folder
-  (fs/find-up ".gitignore" (fs/parent (fs/cwd)))
-  (fs/find-up ".gitignore" "..")
-  (fs/find-up "../.gitignore")
+  ;; find .gitignore starting from the parent folder
+  (fs/find-up ".." ".gitignore")
 
-  ;; find the git work tree using a predicate
-  (let [git-work-tree? #(fs/exists? (fs/path % ".git"))]
-    (fs/find-up git-work-tree?))
-
-  ;; find root of Clojure project we're in (if any).
-  (let [file-finder (fn [path]
-                      #(first (fs/glob path %)))
-        clj-project? (some-fn (file-finder "project.clj") (file-finder "deps.edn"))]
-    (fs/find-up clj-project?))
-
-  ;; `start` may be point to a file
-  (fs/find-up ".gitignore" "~/.gitignore") ;; => /full/path/to/home/.gitignore
-
-  ;; find all .gitignore files in CWD and ancestors
-  (let [to-find ".gitignore"]
-    (take-while some?
-      (iterate #(fs/find-up (fs/parent to-find) %) (find-up to-find))))
+  ;; `start` may point to a file
+  (fs/find-up (fs/path (fs/home) ".gitconfig") ".gitignore")
   ```
   
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1277-L1337">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1277-L1315">Source</a></sub></p>
 
 ## <a name="babashka.fs/get-attribute">`get-attribute`</a><a name="babashka.fs/get-attribute"></a>
 ``` clojure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Babashka [fs](https://github.com/babashka/fs): file system utility library for C
 
 ## Unreleased
 
+- [#112](https://github.com/babashka/fs/issues/112): add `find-up` function to find file or folder by traversing up ([@eval](https://github.com/eval))
 - [#102](https://github.com/babashka/fs/issues/102): add `gzip` and `gunzip` functions
 - [#113](https://github.com/babashka/fs/issues/113): `fs/glob`: enable `:hidden` (when not already set) when `pattern` starts with dot ([@eval](https://github.com/eval)).
 

--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -740,3 +740,72 @@
                 fs/delete-on-exit)
           file-in-dir (fs/create-temp-file {:dir dir})]
       (is (= (str (fs/owner dir)) (str (fs/owner file-in-dir)))))))
+
+
+(deftest find-up-test
+  (let [cwd-name      (fs/file-name (fs/cwd))
+        path->depth   #(count (seq %))
+        path-til-root #(str/join fs/file-separator (take (path->depth %) (repeat "..")))
+        root-til-path #(fs/relativize (.getRoot %) %)] ;; e.g. Users\Foo\fs or Users/foo/fs
+    (testing "searching up from cwd"
+      (is (nil? (fs/find-up nil))
+          "it should accept nil as this allows for traversing up via parent of previous result")
+      (is (= (fs/path (fs/cwd) "README.md")
+             (fs/find-up "README.md"))
+          "it should find an existing file in CWD")
+      (is (= (fs/path (fs/cwd) "README.md")
+             (fs/find-up (fs/path "README.md")))
+          "it should accept a path")
+      (is (= (fs/path (fs/cwd) "src" "babashka" "fs.cljc")
+             (fs/find-up (fs/path "src" "babashka" "fs.cljc")))
+          "it should accept a deeper path to find")
+      (is (= (fs/cwd)
+             (fs/normalize (fs/find-up (str ".." fs/file-separator cwd-name))))
+          "it should find cwd with a relative path")
+      (let [cwd-til-root (path-til-root (fs/cwd))]
+        (is (fs/same-file? (fs/cwd)
+                           (fs/find-up (str cwd-til-root fs/file-separator (root-til-path (fs/cwd)))))
+            "it should accept a relative path")
+        (is (nil? (fs/find-up (str cwd-til-root
+                                   fs/file-separator ".." ;; one below
+                                   (root-til-path (fs/cwd)))))
+            "it should yield nil when a relative `file` goes below root"))
+      (is (instance? java.nio.file.Path (fs/find-up "README.md"))
+          "it should yield a path"))
+
+    (testing "providing a start-folder"
+      (is (nil? (fs/find-up ".gitignore" nil))
+          "it should accept nil as `start` and return nil")
+      (is (= (fs/path (fs/cwd) ".gitignore")
+             (fs/find-up ".gitignore" "."))
+          "it should accept \".\" as `start`")
+      (is (= (fs/path (fs/cwd))
+             (fs/find-up cwd-name ".."))
+          "it should find cwd starting at \"..\"")
+      (let [tmp-path            (fs/create-dirs (fs/path (temp-dir) "find-up-test"))
+            some-folder         (fs/create-dirs (fs/path tmp-path "some-folder"))
+            some-file           (fs/create-file (fs/path tmp-path "some-file"))
+            root-til-start      (root-til-path some-folder)
+            tilde-dotdots-start (let [home-til-root (path-til-root (fs/home))]
+                                  (str "~" fs/file-separator
+                                       home-til-root fs/file-separator
+                                       root-til-start))]
+        (is (fs/same-file? some-file
+                           (fs/find-up "some-file" some-folder))
+            "it should find files in a parent")
+        (is (fs/same-file? some-file
+                           (fs/find-up "some-file" tilde-dotdots-start))
+            "it should accept a string containing ~ as `start`")
+        (is (thrown-with-msg? IllegalArgumentException #"Provided start does not exist"
+                              (fs/find-up "some-file" (fs/path some-folder "bogus")))
+            "should throw an exception when `start` does not exist")
+        (testing "`start` being a file"
+          (let [sibling-of-in-parent (fs/create-file (fs/path some-folder "in-start"))]
+            (is (fs/same-file? some-file
+                               (fs/find-up "some-file" sibling-of-in-parent))
+                "it should accept `start` being a file")))))
+
+    (testing "passing a predicate"
+      (is (= (fs/cwd)
+             (let [git-working-tree? #(-> % (fs/path ".git") fs/exists?)]
+               (fs/find-up git-working-tree?)))))))


### PR DESCRIPTION
Issue https://github.com/babashka/fs/issues/112

Applied to [clj-kondo](https://github.com/clj-kondo/clj-kondo/compare/master...eval:clj-kondo:upgrade-fs).

## considerations

- currently raises on `start` not existing (as fs/parent happily traverses up existing or not) - maybe this should be configurable (seems needed for the clj-kondo-example that is currently not strict)
- return file or path - currently going with path to be in line with e.g. `glob`
- [X] tests are very extensive - might be pruned