### PR TITLE
Preserve file provider protocol for path

### DIFF
--- a/src/babashka/fs.cljc
+++ b/src/babashka/fs.cljc
@@ -55,7 +55,9 @@
   (^Path [f]
    (as-path f))
   (^Path [parent child]
-   (as-path (io/file (as-file parent) (as-file child))))
+   (if parent
+     (.resolve (as-path parent) (as-path child))
+     (as-path child)))
   (^Path [parent child & more]
    (reduce path (path parent child) more)))
 


### PR DESCRIPTION
I was able to confirm this fixes #135 when used with the `gs` file provider but unsure we want to add a test using it.