### PR TITLE
docstrings: use wikilinks instead of backticks

### DIFF
--- a/API.md
+++ b/API.md
@@ -18,14 +18,14 @@
     -  [`delete`](#babashka.fs/delete) - Deletes f.
     -  [`delete-if-exists`](#babashka.fs/delete-if-exists) - Deletes f if it exists.
     -  [`delete-on-exit`](#babashka.fs/delete-on-exit) - Requests delete on exit via <code>File#deleteOnExit</code>.
-    -  [`delete-tree`](#babashka.fs/delete-tree) - Deletes a file tree using <code>walk-file-tree</code>.
+    -  [`delete-tree`](#babashka.fs/delete-tree) - Deletes a file tree using [[walk-file-tree]].
     -  [`directory?`](#babashka.fs/directory?) - Returns true if f is a directory, using Files/isDirectory.
     -  [`ends-with?`](#babashka.fs/ends-with?) - Returns true if path this ends with path other.
     -  [`exec-paths`](#babashka.fs/exec-paths) - Returns executable paths (using the PATH environment variable).
     -  [`executable?`](#babashka.fs/executable?) - Returns true if f is executable.
     -  [`exists?`](#babashka.fs/exists?) - Returns true if f exists.
     -  [`expand-home`](#babashka.fs/expand-home) - If <code>path</code> begins with a tilde (<code>~</code>), expand the tilde to the value of the <code>user.home</code> system property.
-    -  [`extension`](#babashka.fs/extension) - Returns the extension of a file via <code>split-ext</code>.
+    -  [`extension`](#babashka.fs/extension) - Returns the extension of a file via [[split-ext]].
     -  [`file`](#babashka.fs/file) - Coerces one arg into a File, or combines multiple paths into one.
     -  [`file-name`](#babashka.fs/file-name) - Returns the name of the file or directory.
     -  [`file-separator`](#babashka.fs/file-separator) - The system-dependent default name-separator character (as string).
@@ -54,7 +54,7 @@
     -  [`posix-file-permissions`](#babashka.fs/posix-file-permissions)
     -  [`read-all-bytes`](#babashka.fs/read-all-bytes) - Returns contents of file as byte array.
     -  [`read-all-lines`](#babashka.fs/read-all-lines) - Read all lines from a file.
-    -  [`read-attributes`](#babashka.fs/read-attributes) - Same as <code>read-attributes*</code> but turns attributes into a map and keywordizes keys.
+    -  [`read-attributes`](#babashka.fs/read-attributes) - Same as [[read-attributes*]] but turns attributes into a map and keywordizes keys.
     -  [`read-attributes*`](#babashka.fs/read-attributes*) - Reads attributes via Files/readAttributes.
     -  [`read-link`](#babashka.fs/read-link) - Reads the target of a symbolic link.
     -  [`readable?`](#babashka.fs/readable?) - Returns true if f is readable.
@@ -72,7 +72,7 @@
     -  [`split-paths`](#babashka.fs/split-paths) - Splits a path list given as a string joined by the OS-specific path-separator into a vec of paths.
     -  [`starts-with?`](#babashka.fs/starts-with?) - Returns true if path this starts with path other.
     -  [`str->posix`](#babashka.fs/str->posix) - Converts a string to a set of PosixFilePermission.
-    -  [`strip-ext`](#babashka.fs/strip-ext) - Strips extension via <code>split-ext</code>.
+    -  [`strip-ext`](#babashka.fs/strip-ext) - Strips extension via [[split-ext]].
     -  [`sym-link?`](#babashka.fs/sym-link?) - Determines if <code>f</code> is a symbolic link via <code>java.nio.file.Files/isSymbolicLink</code>.
     -  [`temp-dir`](#babashka.fs/temp-dir) - Returns <code>java.io.tmpdir</code> property as path.
     -  [`unixify`](#babashka.fs/unixify) - Returns path as string with Unix-style file separators (<code>/</code>).
@@ -80,7 +80,7 @@
     -  [`update-file`](#babashka.fs/update-file) - Updates the contents of text file <code>path</code> using <code>f</code> applied to old contents and <code>xs</code>.
     -  [`walk-file-tree`](#babashka.fs/walk-file-tree) - Walks f using Files/walkFileTree.
     -  [`which`](#babashka.fs/which) - Returns Path to first executable <code>program</code> found in <code>:paths</code> <code>opt</code>, similar to the which Unix command.
-    -  [`which-all`](#babashka.fs/which-all) - Returns every Path to <code>program</code> found in (<code>exec-paths</code>).
+    -  [`which-all`](#babashka.fs/which-all) - Returns every Path to <code>program</code> found in ([[exec-paths]]).
     -  [`windows?`](#babashka.fs/windows?) - Returns true if OS is Windows.
     -  [`with-temp-dir`](#babashka.fs/with-temp-dir) - Evaluates body with binding-name bound to the result of <code>(create-temp-dir options)</code>, then cleans up.
     -  [`writable?`](#babashka.fs/writable?) - Returns true if f is writable.
@@ -130,7 +130,7 @@ Function.
 
 Returns the canonical path via
   java.io.File#getCanonicalPath. If `:nofollow-links` is set, then it
-  will fall back on [`absolutize`](#babashka.fs/absolutize) + `normalize.` This function can be used
+  will fall back on [`absolutize`](#babashka.fs/absolutize) + [`normalize`](#babashka.fs/normalize). This function can be used
   as an alternative to [`real-path`](#babashka.fs/real-path) which requires files to exist.
 <p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L176-L185">Source</a></sub></p>
 
@@ -429,8 +429,8 @@ Returns true if f exists.
 ```
 Function.
 
-If [`path`](#babashka.fs/path) begins with a tilde (`~`), expand the tilde to the value
-  of the `user.home` system property. If the [`path`](#babashka.fs/path) begins with a
+If `path` begins with a tilde (`~`), expand the tilde to the value
+  of the `user.home` system property. If the `path` begins with a
   tilde immediately followed by some characters, they are assumed to
   be a username. This is expanded to the path to that user's home
   directory. This is (naively) assumed to be a directory with the same
@@ -1050,7 +1050,7 @@ Unzips `zip-file` to `dest` directory (default `"."`).
 ```
 Function.
 
-Updates the contents of text file [`path`](#babashka.fs/path) using `f` applied to old contents and `xs`.
+Updates the contents of text file `path` using `f` applied to old contents and `xs`.
   Returns the new contents.
 
   Options:
@@ -1083,7 +1083,7 @@ Walks f using Files/walkFileTree. Visitor functions: :pre-visit-dir,
 Function.
 
 Returns Path to first executable `program` found in `:paths` `opt`, similar to the which Unix command.
-  Default for `:paths` is `(exec-paths)`.
+  Default for `:paths` is ([`exec-paths`](#babashka.fs/exec-paths)).
 
   On Windows, searches for `program` with filename extensions specified in `:win-exts` `opt`.
   Default is `["com" "exe" "bat" "cmd"]`.
@@ -1160,7 +1160,7 @@ Returns true if f is writable
 ```
 Function.
 
-Writes `bytes` to [`path`](#babashka.fs/path) via `java.nio.file.Files/write`.
+Writes `bytes` to `path` via `java.nio.file.Files/write`.
   Supported options:
   * `:create` (default `true`)
   * `:truncate-existing` (default `true`)
@@ -1184,7 +1184,7 @@ Writes `bytes` to [`path`](#babashka.fs/path) via `java.nio.file.Files/write`.
 ```
 Function.
 
-Writes `lines`, a seqable of strings to [`path`](#babashka.fs/path) via `java.nio.file.Files/write`.
+Writes `lines`, a seqable of strings to `path` via `java.nio.file.Files/write`.
 
   Supported options:
   * `:charset` (default `"utf-8"`)

--- a/bb.edn
+++ b/bb.edn
@@ -55,4 +55,5 @@
    :task (api/quickdoc {:git/branch "master"
                         :github/repo "https://github.com/babashka/fs"
                         :toc true
-                        :var-links true})}}}
+                        :var-links true
+                        :var-pattern :wikilinks})}}}

--- a/src/babashka/fs.cljc
+++ b/src/babashka/fs.cljc
@@ -176,8 +176,8 @@
 (defn canonicalize
   "Returns the canonical path via
   java.io.File#getCanonicalPath. If `:nofollow-links` is set, then it
-  will fall back on `absolutize` + `normalize.` This function can be used
-  as an alternative to `real-path` which requires files to exist."
+  will fall back on [[absolutize]] + [[normalize]]. This function can be used
+  as an alternative to [[real-path]] which requires files to exist."
   (^Path [f] (canonicalize f nil))
   (^Path [f {:keys [:nofollow-links]}]
    (if nofollow-links
@@ -494,7 +494,7 @@
 
 (defn copy-tree
   "Copies entire file tree from src to dest. Creates dest if needed
-  using `create-dirs`, passing it the `:posix-file-permissions`
+  using [[create-dirs]], passing it the `:posix-file-permissions`
   option. Supports same options as copy.
   Returns `dest` as path"
   ([src dest] (copy-tree src dest nil))
@@ -553,16 +553,16 @@
   "Creates a directory using [Files#createTempDirectory](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#createTempDirectory-java.nio.file.Path-java.lang.String-java.nio.file.attribute.FileAttribute...-).
 
   This function does not set up any automatic deletion of the directories it
-  creates. See `with-temp-dir` for that functionality.
+  creates. See [[with-temp-dir]] for that functionality.
 
   Options:
   - `:dir`: Directory in which to create the new directory. Defaults to default
-  system temp dir (e.g. `/tmp`); see `temp-dir`. Must already exist.
+  system temp dir (e.g. `/tmp`); see [[temp-dir]]. Must already exist.
   - `:prefix`: Provided as a hint to the process that generates the name of the
   new directory. In most cases, this will be the beginning of the new directory
   name. Defaults to a random (v4) UUID.
   - `:posix-file-permissions`: The new directory will be created with these
-  permissions, given as a String as described in `str->posix`. If not
+  permissions, given as a String as described in [[str->posix]]. If not
   specified, uses the file system default permissions for new directories.
   - :warning: `:path` **[DEPRECATED]** Previous name for `:dir`, kept
   for backwards compatibility. If both `:path` and `:dir` are given (don't do
@@ -591,11 +591,11 @@
   "Creates an empty file using [Files#createTempFile](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#createTempFile-java.nio.file.Path-java.lang.String-java.lang.String-java.nio.file.attribute.FileAttribute...-).
 
   This function does not set up any automatic deletion of the files it
-  creates. Create the file in a `with-temp-dir` for that functionality.
+  creates. Create the file in a [[with-temp-dir]] for that functionality.
 
   Options:
   - `:dir`: Directory in which to create the new file. Defaults to default
-  system temp dir (e.g. `/tmp`); see `temp-dir`. Must already exist.
+  system temp dir (e.g. `/tmp`); see [[temp-dir]]. Must already exist.
   - `:prefix`: Provided as a hint to the process that generates the name of the
   new file. In most cases, this will be the beginning of the new file name.
   Defaults to a random (v4) UUID.
@@ -603,7 +603,7 @@
   new file. In most cases, this will be the end of the new file name.
   Defaults to a random (v4) UUID.
   - `:posix-file-permissions`: The new file will be created with these
-  permissions, given as a String as described in `str->posix`. If not
+  permissions, given as a String as described in [[str->posix]]. If not
   specified, uses the file system default permissions for new files.
   - :warning: `:path` **[DEPRECATED]** Previous name for `:dir`, kept
   for backwards compatibility. If both `:path` and `:dir` are given (don't do
@@ -676,7 +676,7 @@
   (Files/isSymbolicLink (as-path f)))
 
 (defn delete-tree
-  "Deletes a file tree using `walk-file-tree`. Similar to `rm -rf`. Does not follow symlinks.
+  "Deletes a file tree using [[walk-file-tree]]. Similar to `rm -rf`. Does not follow symlinks.
    `force` ensures read-only directories/files are deleted. Similar to `chmod -R +wx` + `rm -rf`"
   ;; See delete-permission-assumptions-test
   ;; Implementation with the force flag is based on those assumptions
@@ -701,7 +701,7 @@
   "Creates empty file using `Files#createFile`.
 
   File permissions can be specified with an `:posix-file-permissions` option.
-  String format for posix file permissions is described in the `str->posix` docstring."
+  String format for posix file permissions is described in the [[str->posix]] docstring."
   ([path]
    (create-file path nil))
   ([path {:keys [:posix-file-permissions]}]
@@ -799,7 +799,7 @@
      attrs)))
 
 (defn read-attributes
-  "Same as `read-attributes*` but turns attributes into a map and keywordizes keys.
+  "Same as [[read-attributes*]] but turns attributes into a map and keywordizes keys.
   Keywordizing can be changed by passing a :key-fn in the options map."
   ([path attributes]
    (read-attributes path attributes nil))
@@ -897,14 +897,14 @@
          [path-str nil])))))
 
 (defn strip-ext
-  "Strips extension via `split-ext`."
+  "Strips extension via [[split-ext]]."
   ([path]
    (strip-ext path nil))
   ([path {:keys [ext] :as opts}]
    (first (split-ext path opts))))
 
 (defn extension
-  "Returns the extension of a file via `split-ext`."
+  "Returns the extension of a file via [[split-ext]]."
   [path]
   (-> path split-ext last))
 
@@ -929,7 +929,7 @@
 
 (defn which
   "Returns Path to first executable `program` found in `:paths` `opt`, similar to the which Unix command.
-  Default for `:paths` is `(exec-paths)`.
+  Default for `:paths` is ([[exec-paths]]).
 
   On Windows, searches for `program` with filename extensions specified in `:win-exts` `opt`.
   Default is `[\"com\" \"exe\" \"bat\" \"cmd\"]`.
@@ -982,7 +982,7 @@
          (if (:all opts) results (first results)))))))
 
 (defn which-all
-  "Returns every Path to `program` found in (`exec-paths`). See `which`."
+  "Returns every Path to `program` found in ([[exec-paths]]). See [[which]]."
   ([program] (which-all program nil))
   ([program opts]
    (which program (assoc opts :all true))))
@@ -1201,10 +1201,10 @@
 
 (defmacro with-temp-dir
   "Evaluates body with binding-name bound to the result of `(create-temp-dir
-  options)`, then cleans up. See [`create-temp-dir`](#babashka.fs/create-temp-dir)
+  options)`, then cleans up. See [[create-temp-dir]]
   for valid `options`.
 
-  The directory will be removed with `delete-tree` on exit from the scope.
+  The directory will be removed with [[delete-tree]] on exit from the scope.
 
   Example:
 


### PR DESCRIPTION
This allows us to be deliberate with var links and to not automatically, for example, link a `path` arg to the `path` var.

Also nice for cljdoc which only links to vars with wikilinks.

I notice the quickdoc toc summary uses the wikilink syntax which is probably not ideal. I can swing back to quickdoc to address that later if you'd like.

Contributes to #160

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/fs/blob/master/CHANGELOG.md) file with a description of the addressed issue.
