### PR TITLE
test & ci: explicitly support clojure >= 1.10.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,4 @@ jobs:
           restore-keys: cljdeps-
 
       - name: Test
-        run: bb test-all
+        run: bb test-all :clj-all

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![bb built-in](https://raw.githubusercontent.com/babashka/babashka/master/logo/built-in-badge.svg)](https://book.babashka.org#badges)
 
 File system utilities. This library can used from:
-- [Clojure on the JVM](https://www.clojure.org/guides/install_clojure) - we support Java 11 and above.
+- [Clojure on the JVM](https://www.clojure.org/guides/install_clojure) - we support Clojure 1.10.3 and above on Java 11 and above.
 - [babashka](https://github.com/babashka/babashka) - it has been a built-in library since babashka v0.2.9.
 
 ## Why

--- a/bb.edn
+++ b/bb.edn
@@ -7,7 +7,35 @@
              [clojure.edn :as edn]
              [clojure.string :as str])
   :init (do
-          (defn from-scratch-cwd [desc aliases]
+          (defn parse-clj-version []
+            (let [args *command-line-args*
+                  farg (first *command-line-args*)
+               farg (if (and farg (str/starts-with? farg "clj-"))
+                      (str ":" farg)
+                      farg)
+               clj-version-aliases (->> "deps.edn"
+                                        slurp
+                                        edn/read-string
+                                        :aliases
+                                        keys
+                                        (map str)
+                                        (filter (fn [a] (-> a name (str/starts-with? ":clj-"))))
+                                        (into []))]
+              (cond
+                (nil? farg) [[:clj-1.12] []]
+
+                (= ":clj-all" farg) [clj-version-aliases (rest args)]
+
+                (and (str/starts-with? farg ":clj-")
+                     (not (some #{farg} clj-version-aliases)))
+                (throw (ex-info (format "%s not recognized, valid clj- args are: %s or \":clj-all\""
+                                        farg clj-version-aliases) {}))
+
+                (some #{farg} clj-version-aliases) [[farg] (rest args)]
+
+                :else [[":clj-1.12"] args])))
+
+          (defn from-scratch-cwd [desc aliases args]
             (let [test-cwd "target/test-cwd"
                   cp (str/trim (with-out-str (clojure (str "-Spath -M" (str/join aliases)))))
                   cp (->> (fs/split-paths cp)
@@ -23,18 +51,30 @@
               (apply clojure
                      {:dir test-cwd}
                      "-Scp" cp
-                     "-M" (into main-opts *command-line-args*)))))
+                     "-M" (into main-opts args)))))
 
   test
-  {:doc "Run default tests"
-   :task (apply clojure {:extra-env {(if (fs/windows?) "Path" "PATH") (str "on-path" fs/path-separator (System/getenv "PATH"))}}
-                "-M:test-runner:test"
-                *command-line-args*)}
+  {:doc "Run default tests, optionally specify clj-version (ex :clj-1.10, :clj-11, :clj-12 (default) or :clj-all)"
+   :task (let [[aliases args] (parse-clj-version)]
+           (doseq [alias aliases]
+             (do
+               (println (format "-[Running test for %s]-" alias))
+               (apply clojure {:extra-env {(if (fs/windows?) "Path" "PATH") (str "on-path" fs/path-separator (System/getenv "PATH"))}}
+                      (format "-M%s:test-runner:test" alias)
+                      args))))}
 
   test-cwd
-  {:doc "Run current working directory tests (from scratch cwd)"
-   :task (from-scratch-cwd "tests" [:test-runner :test :test-cwd])}
+  {:doc "Run current working directory tests (from scratch cwd), optional specify clj-version (see test)"
+   :task (let [[aliases args] (parse-clj-version)]
+           (doseq [alias aliases]
+             (do
+               (println (format "-[Running test-cwd for %s]-" alias))
+               (from-scratch-cwd "tests" [alias :test-runner :test :test-cwd] args))))}
 
+  test-all
+  {:doc "Run all tests, optionally specify clj-version (see test)"
+   :depends [test test-cwd]}
+  
   dev
   {:doc "Launch an nREPL for default tests"
    :task (apply clojure {:extra-env {(if (fs/windows?) "Path" "PATH") (str "on-path" fs/path-separator (System/getenv "PATH"))}}
@@ -43,11 +83,7 @@
 
   dev-cwd
   {:doc "Launch an nREPL for cwd tests (from scratch cwd)"
-   :task (from-scratch-cwd "repl" [:test-runner :test :test-cwd :repl-runner])}
-
-  test-all
-  {:doc "Run all tests"
-   :depends [test test-cwd]}
+   :task (from-scratch-cwd "repl" [:test-runner :test :test-cwd :repl-runner] *command-line-args*)}
 
   quickdoc
   {:doc "Invoke quickdoc"

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,9 @@
 {:deps {}
- :aliases {:test-runner {:extra-paths ["test"]
+ :aliases {:clj-1.10 {:extra-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
+           :clj-1.11 {:extra-deps {org.clojure/clojure {:mvn/version "1.11.3"}}}
+           :clj-1.12 {:extra-deps {org.clojure/clojure {:mvn/version "1.12.3"}}}
+
+           :test-runner {:extra-paths ["test"]
                          :extra-deps {io.github.cognitect-labs/test-runner
                                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}
                                       clj-kondo/clj-kondo {:mvn/version "2025.10.23"}

--- a/test/babashka/fs_cwd_test.clj
+++ b/test/babashka/fs_cwd_test.clj
@@ -52,8 +52,8 @@
   (let [version (-> (System/getProperty "java.version")
                     (str/split #"\."))]
     (if (= "1" (first version))
-      (parse-long (second version))
-      (parse-long (first version)))))
+      (Long/valueOf (second version))
+      (Long/valueOf (first version)))))
 
 ;;
 ;; Empty-string tests

--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -810,7 +810,8 @@
     (is (= (fs/exists? "c:/123:456") false))))
 
 (deftest write-bytes-test
-  (let [f (fs/path (fs/temp-dir) (str (gensym)))]
+  (let [f (-> (fs/path (fs/temp-dir) (str (gensym)))
+              fs/delete-on-exit)]
     (fs/write-bytes f (.getBytes (String. "foo")))
     (is (= "foo" (String. (fs/read-all-bytes f))))
     ;; again, truncation behavior:
@@ -820,7 +821,8 @@
     (is (= "foobar" (String. (fs/read-all-bytes f))))))
 
 (deftest write-lines-test
-  (let [f (fs/path (fs/temp-dir) (str (gensym)))]
+  (let [f (-> (fs/path (fs/temp-dir) (str (gensym)))
+              fs/delete-on-exit)]
     (fs/write-lines f (repeat 3 "foo"))
     (is (= (repeat 3 "foo") (fs/read-all-lines f)))
     ;; again, truncation behavior:
@@ -844,11 +846,14 @@
     (let [new-val (fs/update-file file str (rand))]
       (is (= new-val (slurp file)))))
 
-  (let [file (fs/file (fs/temp-dir) (str (gensym)))]
+  (let [file (-> (fs/file (fs/temp-dir) (str (gensym)))
+                 fs/delete-on-exit)]
     (spit file ", ")
     (is (= "foo, bar, baz" (fs/update-file file str/join ["foo" "bar" "baz"]))))
 
-  (let [path (fs/path (fs/file (fs/temp-dir) (str (gensym))))]
+  (let [path (-> (fs/file (fs/temp-dir) (str (gensym)))
+                 fs/delete-on-exit
+                 fs/path)]
     (spit (fs/file path) "foo")
     (is (= "foobar" (fs/update-file path str "bar")))))
 

--- a/test/babashka/test_report.clj
+++ b/test/babashka/test_report.clj
@@ -4,7 +4,7 @@
 (def platform
   (if-let [bb-version (System/getProperty "babashka.version")]
     (str "bb " bb-version)
-    (str "jdk " (System/getProperty "java.version"))))
+    (str "jdk " (System/getProperty "java.version") " clj " (clojure-version))))
 
 (defmethod clojure.test/report :begin-test-var [m]
   (let [test-name (-> m :var meta :name)]


### PR DESCRIPTION
Run `test`, `test-cwd` or `test-all` tasks with `:clj-1.10`, `:clj-1.11`, `:clj-1.12` (default) or `:clj-all`.

CI now runs `test-all :clj-all`.

Mention min clojure version in README.

Adjustments:
- always delete-on-exit for (gensym) based files, I found they reoccurred when switching Clojure versions and caused tests to fail.
- adjust test that used `to-long` which is not available in clojure 1.10

Closes #168

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/fs/blob/master/CHANGELOG.md) file with a description of the addressed issue.
