### PR TITLE
test: increase sleep

### DIFF
--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -587,7 +587,7 @@
     (let [td0 (fs/create-temp-dir)
           anchor (fs/file td0 "f0")
           _ (spit anchor "content")
-          _ (Thread/sleep 1)
+          _ (Thread/sleep 50)
           td1 (fs/create-temp-dir)
           f1 (fs/file td1 "f1")
           _ (spit f1 "content")


### PR DESCRIPTION
The `modified-since-test` failed once on CI.
Let's increase sleep from 1ms to 50ms.
This might reduce the chance of a sporadic failure in the future.

(as discussed on Slack)

Please answer the following questions and leave the below in as part of your PR.

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/fs/blob/master/CHANGELOG.md) file with a description of the addressed issue.
