### PR TITLE
ci: restore macOS caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,6 @@ jobs:
 
       # Optional step:
       - name: Cache clojure dependencies
-        # TODO: remove next line after working again
-        #  temporarily work around https://github.com/actions/runner-images/issues/13341
-        #  by disabling caching for macOS
-        if: ${{ runner.os != 'macOS' }}
         uses: actions/cache@v4
         with:
           path: |


### PR DESCRIPTION
GitHub seems to have fixed their macOS runners

See: https://github.com/actions/runner-images/issues/13341#issuecomment-3572431071

Please answer the following questions and leave the below in as part of your PR.

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/fs/blob/master/CHANGELOG.md) file with a description of the addressed issue.
