### PR TITLE
Step 3f: decouple more tests

### DIFF
--- a/src/babashka/fs.cljc
+++ b/src/babashka/fs.cljc
@@ -766,8 +766,8 @@
 (defn delete-tree
   "Deletes a file tree `root` using [[walk-file-tree]]. Similar to `rm -rf`. Does not follow symlinks.
    `force` ensures read-only directories/files are deleted. Similar to `chmod -R +wx` + `rm -rf`"
-  ;; See delete-permission-assumptions-test
-  ;; Implementation with the force flag is based on those assumptions
+  ;; See: delete-permissions-* tests
+  ;; Implementation with the force flag is based on assumptions in those tests
   ([root] (delete-tree root nil))
   ([root {:keys [force]}]
    (when (exists? root {:nofollow-links true})


### PR DESCRIPTION
Step 3f for #158: decouple a small digestible set of tests from fs source tree:

- `delete-permission-assumption-test` split out to:
  - `delete-permissions-unix-ro-file-test`
  - `delete-permissions-unix-file-in-ro-dir-throws-test`
  - `delete-permissions-windows-idempotently-writable-file-test`
  - `delete-permissions-windows-ro-file-throws-test`
  - `delete-permissions-windows-file-in-ro-dir-test`
- `delete-tree-test` now (newly) tests deletion of non-nested tree
  - factored out `delete-tree-nested-test`
  - factored out `delete-tree-ok-if-dir-missing-test`
  - factored out `delete-tree-does-not-follow-symlink-test`
  - factored out `delete-tree-force-deletes-ro-dirs-and-files-test`

Use matcher combinators for clearer and more detailed assertions.

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/fs/blob/master/CHANGELOG.md) file with a description of the addressed issue.
