### PR TITLE
Step 2g: decouple more tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,10 @@ The underlying JDK file APIs (and, by extension, babashka.fs) typically consider
 ### creation-time
 Depending on which OS and JDK version you are running, `creation-time` might return unexpected results.
 As of this writing, our testing has revealed: 
+
 - Windows - returns creation time as expected
-- macOS 
-  - after Java 17 returns creation time as expected
-  - otherwise returns modified time
-- Linux 
-  - before Java 17 returns modified time
-  - otherwise returns creation time
+- macOS - returns creation time as expected
+- Linux - returns modified time before JDK 17, otherwise returns creation time as expected
 
 See [JDK-8316304](https://bugs.openjdk.org/browse/JDK-8316304).
 
@@ -93,7 +90,7 @@ Depending on which OS and JDK version you are running, `set-creation-time` might
 As of this writing, our testing has revealed:
 - Windows - sets creation time as expected
 - macOS
-  - after Java 17 sets creation time as expected
+  - after Java 17 sets creation time as expected, otherwise seems to have no effect
   - otherwise has no effect
 - Linux - seems to have no effect
 

--- a/deps.edn
+++ b/deps.edn
@@ -6,6 +6,7 @@
            :test-runner {:extra-paths ["test"]
                          :extra-deps {io.github.cognitect-labs/test-runner
                                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}
+                                      babashka/process {:mvn/version "0.6.25"}
                                       clj-kondo/clj-kondo {:mvn/version "2025.10.23"}
                                       nubank/matcher-combinators {:mvn/version "3.9.2"}}
                          :main-opts ["-m" "cognitect.test-runner"

--- a/test/babashka/fs_test_util.clj
+++ b/test/babashka/fs_test_util.clj
@@ -1,6 +1,8 @@
 (ns babashka.fs-test-util
   (:require [babashka.fs :as fs]
-            [clojure.string :as str]))
+            [babashka.process :as process]
+            [clojure.string :as str])
+  (:import [java.lang ProcessHandle]))
 
 (defn clean-cwd []
   (when-not (str/ends-with? (System/getProperty "user.dir") (str "target" fs/file-separator "test-cwd"))
@@ -23,3 +25,44 @@
                :attr (dissoc (fs/read-attributes p "*") :lastAccessTime :fileKey)}))
        (sort-by :path)
        (into [])))
+
+(defn os []
+  (let [os-name (str/lower-case (System/getProperty "os.name"))]
+    (condp re-find os-name
+      #"win" :win
+      #"mac" :mac
+      #"(nix|nux|aix)" :unix
+      #"sunos" :solaris
+      :unknown)))
+
+(defn- umask->rwx [umask]
+  (reduce (fn [acc n]
+            (str acc (let [n (Long/parseLong (str n))]
+                       (str 
+                         (if (zero? (bit-and n 4)) "-" "r")
+                         (if (zero? (bit-and n 2)) "-" "w")
+                         (if (zero? (bit-and n 1)) "-" "x")))))
+          ""
+          (subs umask 1)))
+
+(defonce umask (some-> (case (os)
+                         ;; linux has good support for getting umask of current process
+                         :unix (->> (process/shell {:out :string}
+                                                   (format "sh -c \"cat /proc/%d/status\"" (.pid (ProcessHandle/current))))
+                                    :out
+                                    str/split-lines
+                                    (keep #(re-matches #"Umask:\s+(\d+)" %))
+                                    first
+                                    last)
+                         ;; on macos, we only have umask
+                         :mac (-> (process/shell {:out :string}
+                                                 "sh -c umask" )
+                                  :out
+                                  str/trim)
+                         nil)
+                       umask->rwx))
+
+(defn umasked [permissions umask]
+  (apply str (keep (fn [[p u]] (if (= \- u) p \-))
+                   (map vector permissions umask))))
+


### PR DESCRIPTION
(some previous decouple commits show step 3, but this was an off by one typo)

Step 2g for #158: decouple a small digestible set of tests from fs source tree:

Supporting work:
- moved `os` fn from `fs-cwd-test` to `fs-test-util` for reuse
  - noticed/fixed typo in `fw-cwd-test/es-set-creation-time-test`
  - corrected associated note in README
- added umask fns to `fs-test-util` to cover effect of `umask` in tests
  - added `babashka/process` as test dep to support

Tests:
- `move-test` split out to:
  - `move-to-file-test`
  - `move-to-dir-test`
- `set-attribute-test` no longer a need for temp dir
- `list-dirs-and-which-test` no change, already decoupled
- `predicate-test` now easy to be more specific, split out to
  - `readable?-test`
  - `writable?-test`
- `normalize-test` does not rely on fs, make a bit less mysterious
- `temp-dir-test` left as is
- `ends-with?-test` does not rely on fs, make a bit less mysterious
- `posix-test`
  - replace test on `.` with a more predictable/verifiable `create-file` test
  - take effect of `umask` into account in assertions

Strategy for `umask` is to use whatever happens to be in place on linux/macOS OS. This is not ideal, but I think a good-enough compromise for now.

Use matcher combinators for clearer and more detailed assertions.

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/fs/blob/master/CHANGELOG.md) file with a description of the addressed issue.
