### PR TITLE
Step 2i: decouple more tests

### DIFF
--- a/test/babashka/fs_cwd_test.clj
+++ b/test/babashka/fs_cwd_test.clj
@@ -17,13 +17,6 @@
     (spit "da1/da2/da3/da4/f2.ext" "f2.ext")
     (f)))
 
-(defn jdk-major []
-  (let [version (-> (System/getProperty "java.version")
-                    (str/split #"\."))]
-    (if (= "1" (first version))
-      (Long/valueOf (second version))
-      (Long/valueOf (first version)))))
-
 ;;
 ;; es- empty-string tests
 ;; Not all of these require an isolated scratch cwd, but they are grouped here for convenience
@@ -40,7 +33,7 @@
   ;; This is slated to be fixed in jdk26, at the time of this writing, I don't see
   ;; backports planned.
   ;; This test will fail if running from a mapped drive on windows.
-  (if (and (fs/windows?) (>= (jdk-major) 24) (str/starts-with? (util/path->str (fs/canonicalize "")) "//"))
+  (if (and (fs/windows?) (>= (util/jdk-major) 24) (str/starts-with? (util/path->str (fs/canonicalize "")) "//"))
     (throw (ex-info "due to bug JDK-8355342 in jdk24, please run this test on windows from an unmapped drive" {}))
     (is (= (util/path->str (System/getProperty "user.dir")) (util/path->str (fs/canonicalize ""))))))
 
@@ -206,7 +199,7 @@
   (is (thrown? java.io.FileNotFoundException (fs/gzip ""))))
 
 (deftest es-hidden-test
-  (if (and (not (fs/windows?)) (< (jdk-major) 17))
+  (if (and (not (fs/windows?)) (< (util/jdk-major) 17))
     (is (thrown? java.lang.ArrayIndexOutOfBoundsException (fs/hidden? "")))
     (is (= false (fs/hidden? "")))))
 
@@ -327,10 +320,10 @@
       ;; quite a storied history here
       ;; sometimes the correct new creation time is returned
       (or (= :win (util/os))
-          (and (= :mac (util/os)) (> (jdk-major) 17)))
+          (and (= :mac (util/os)) (> (util/jdk-major) 17)))
       (is (= new-create-time (fs/creation-time "")) "returns correct new creation time")
       ;; other times the new modified time is returned in place of creation time
-      (and (= :unix (util/os)) (< (jdk-major) 17))
+      (and (= :unix (util/os)) (< (util/jdk-major) 17))
       (is (= new-modify-time (fs/creation-time "")) "returns new modified time")
       ;; other times old creation time is returned 
       :else

--- a/test/babashka/fs_test_util.clj
+++ b/test/babashka/fs_test_util.clj
@@ -35,6 +35,13 @@
       #"sunos" :solaris
       :unknown)))
 
+(defn jdk-major []
+  (let [version (-> (System/getProperty "java.version")
+                    (str/split #"\."))]
+    (if (= "1" (first version))
+      (Long/valueOf (second version))
+      (Long/valueOf (first version)))))
+
 (defn- umask->rwx [umask]
   (reduce (fn [acc n]
             (str acc (let [n (Long/parseLong (str n))]


### PR DESCRIPTION
Step 2i for #158: decouple a small digestible set of tests from fs source tree:

Supporting work
- move `jdk-major` from `fs-cwd-test` to `test-util` for reuse
- temporarily create a `files*` fn; there should be no need for this at the end of step 2

Tests
- `get-attribute-test` now easy to be more specific
- `file-time-test` no need for temp dir anymore
  - extracted `set-last-modified-time-test`
  - extracted `set-creation-time-test` and got more specific
- `split-ext-test` no change, not coupled
- `extension-test` no change, not coupled
- `strip-ext-test` no change, not coupled
- `modified-since-test` split out to
  - `modified-since-with-sleep-test`
  - `modified-since-no-sleep-test`

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/fs/blob/master/CHANGELOG.md) file with a description of the addressed issue.
