### PR TITLE
dev: don't explicitly delete scratch scratch cwd

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -45,8 +45,9 @@
                           (str/join fs/path-separator))
                   run-alias (last aliases)
                   main-opts (-> "deps.edn" slurp edn/read-string :aliases run-alias :main-opts)]
-              (fs/delete-tree test-cwd)
               (fs/create-dirs test-cwd)
+              (doseq [f (fs/list-dir test-cwd)]
+                (fs/delete-tree f {:force true}))
               (println "Running" desc "from:" test-cwd)
               (apply clojure
                      {:dir test-cwd


### PR DESCRIPTION
I was finding that an open repl session launched by `bb dev` could require a restart after running `bb test` from the terminal.

Not explicitly deleting the scratch test cwd remedies the issue.

PR 1 of 2 for #227

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/fs/blob/master/CHANGELOG.md) file with a description of the addressed issue.
