### PR TITLE
dev: write .nrepl-port file to project root dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,14 +165,11 @@ bb test --var babashka.fs-test/walk-test
 > [!NOTE]
 > To allow us to contrive isolated file system scenarios, tests are always run from the scratch current working directory `./target/test-cwd`.
 
-To fire up a REPL when working on these tests, run:
+To fire up a REPL when working on babashka fs tests, you must run:
 
 ```
 bb dev
 ```
-
-> [!TIP]
-> The `.nrepl-port` file will be generated under `./target/test-cwd/`, so you'll have to type the REPL port in manually when connecting.
 
 ### API Docs
 This project generates API docs with quickdoc, to regenerate `API.md`:

--- a/deps.edn
+++ b/deps.edn
@@ -12,10 +12,11 @@
                          :main-opts ["-m" "cognitect.test-runner"
                                      "--dir" "../.."]}
 
-           :repl-runner {:extra-deps {nrepl/nrepl {:mvn/version "1.5.1"}
+           :repl-runner {:extra-paths ["dev"]
+                         :extra-deps {nrepl/nrepl {:mvn/version "1.5.1"}
                                       refactor-nrepl/refactor-nrepl {:mvn/version "3.11.0"}
                                       cider/cider-nrepl {:mvn/version "0.58.0"}}
                          :jvm-opts ["-XX:-OmitStackTraceInFastThrow" "-Djdk.attach.allowAttachSelf"]
-                         :main-opts  ["-m" "nrepl.cmdline"
+                         :main-opts  ["-m" "babashka.fs.nrepl"
                                       "--middleware" "[refactor-nrepl.middleware/wrap-refactor cider.nrepl/cider-middleware]"
                                       "-i"]}}}

--- a/dev/babashka/fs/nrepl.clj
+++ b/dev/babashka/fs/nrepl.clj
@@ -1,0 +1,25 @@
+(ns babashka.fs.nrepl
+  (:require [nrepl.cmdline :as nrepl-cmdline]
+            [clojure.java.io :as io]))
+
+(defn save-port-file
+  "Babashka fs runs the repl and tests from a scratch test dir under target,
+  we'll search upward for the project root and write our .nrepl-port file there."
+  [{:keys [port] :as _server} _options]
+  (let [cwd (io/file (System/getProperty "user.dir"))
+        project-dir-indicator-file ".clj-kondo" 
+        project-dir (loop [dir cwd]
+                      (cond
+                        (nil? dir) (throw (ex-info (format "Upward search from %s for project root dir (containing %s) not found"
+                                                           cwd project-dir-indicator-file) {}))
+                        (.exists (io/file dir project-dir-indicator-file)) dir 
+                        :else (recur (.getParentFile dir))))
+        port-file (io/file project-dir ".nrepl-port")]
+    (println "Writing:" (str port-file))
+    (.deleteOnExit ^java.io.File port-file)
+    (spit port-file port)))
+
+(defn -main
+  [& args]
+  (with-redefs [nrepl-cmdline/save-port-file save-port-file]
+    (apply nrepl-cmdline/-main args)))


### PR DESCRIPTION
Tests are run from an isolated current working directory under `target/test-cwd`. Both `bb test` and `bb dev` (repl) are therefore run from this cwd.

The nrepl server always writes to `.nrepl-port` to the cwd. Which means it writes to `target/test-cwd/.nrepl-port`. Tooling expects to find `.nrepl-port` in the project root, and therefore do not find it.

This change writes `.nrepl-port` to the project root dir by overriding nrepl server behaviour.

PR 2 of 2 for #227
Closes #227

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/fs/blob/master/CHANGELOG.md) file with a description of the addressed issue.
