### PR TITLE
docs: API review - step 1

### DIFF
--- a/.clj-kondo/imports/babashka/fs/babashka/fs.clj_kondo
+++ b/.clj-kondo/imports/babashka/fs/babashka/fs.clj_kondo
@@ -31,6 +31,6 @@
                     (list*
                      (api/token-node 'let)
                        ;; it doesn't really matter what we bind to, so long as it is bound
-                     (api/vector-node [binding-sym (api/string-node "value")])
+                     (api/vector-node [binding-sym (api/token-node nil)])
                      options ;; avoid unused binding when options is a binding
                      body))}))))))

--- a/API.md
+++ b/API.md
@@ -1,98 +1,98 @@
 # Table of contents
 -  [`babashka.fs`](#babashka.fs) 
-    -  [`absolute?`](#babashka.fs/absolute?) - Returns true if <code>f</code> represents an absolute path via [Path#isAbsolute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#isAbsolute()).
-    -  [`absolutize`](#babashka.fs/absolutize) - Converts <code>f</code> into an absolute <code>Path</code> via [Path#toAbsolutePath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toAbsolutePath()).
-    -  [`canonicalize`](#babashka.fs/canonicalize) - Returns the canonical <code>Path</code> for <code>f</code> via [File#getCanonicalPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getCanonicalPath()).
-    -  [`components`](#babashka.fs/components) - Returns a seq of all components of <code>f</code> as paths.
-    -  [`copy`](#babashka.fs/copy) - Copies <code>src</code> file to <code>dest</code> dir or file using [Files/copy](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#copy(java.nio.file.Path,java.nio.file.Path,java.nio.file.CopyOption...)).
-    -  [`copy-tree`](#babashka.fs/copy-tree) - Copies entire file tree from <code>src</code> to <code>dest</code>.
-    -  [`create-dir`](#babashka.fs/create-dir) - Creates dir using [Files/createDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectory(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
-    -  [`create-dirs`](#babashka.fs/create-dirs) - Creates directories for <code>path</code> using [Files/createDirectories](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectories(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
-    -  [`create-file`](#babashka.fs/create-file) - Creates empty file at <code>path</code> using [Files/createFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createFile(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
-    -  [`create-link`](#babashka.fs/create-link) - Create a new <code>link</code> (directory entry) for an <code>existing</code> file via [Files/createLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createLink(java.nio.file.Path,java.nio.file.Path)).
-    -  [`create-sym-link`](#babashka.fs/create-sym-link) - Create a symbolic <code>link</code> to <code>target</code> via [Files/createSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createSymbolicLink(java.nio.file.Path,java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
-    -  [`create-temp-dir`](#babashka.fs/create-temp-dir) - Creates a directory using [Files/createTempDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createTempDirectory(java.nio.file.Path,java.lang.String,java.nio.file.attribute.FileAttribute...)).
-    -  [`create-temp-file`](#babashka.fs/create-temp-file) - Creates an empty file using [Files/createTempFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createTempFile(java.nio.file.Path,java.lang.String,java.lang.String,java.nio.file.attribute.FileAttribute...)).
-    -  [`creation-time`](#babashka.fs/creation-time) - Returns creation time of <code>f</code> as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
-    -  [`cwd`](#babashka.fs/cwd) - Returns current working directory as <code>Path</code>.
-    -  [`delete`](#babashka.fs/delete) - Deletes <code>f</code> using [Files/delete](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#delete(java.nio.file.Path)).
-    -  [`delete-if-exists`](#babashka.fs/delete-if-exists) - Deletes <code>f</code> if it exists via [Files/deleteIfExists](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#deleteIfExists(java.nio.file.Path)).
-    -  [`delete-on-exit`](#babashka.fs/delete-on-exit) - Requests delete of file <code>f</code> on exit via [File#deleteOnExit](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#deleteOnExit()).
-    -  [`delete-tree`](#babashka.fs/delete-tree) - Deletes a file tree <code>root</code> using [<code>walk-file-tree</code>](#babashka.fs/walk-file-tree).
-    -  [`directory?`](#babashka.fs/directory?) - Returns true if <code>f</code> is a directory, using [Files/isDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isDirectory(java.nio.file.Path,java.nio.file.LinkOption...)).
-    -  [`ends-with?`](#babashka.fs/ends-with?) - Returns <code>true</code> if path <code>this</code> ends with path <code>other</code> via [Path#endsWith](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#endsWith(java.nio.file.Path)).
-    -  [`exec-paths`](#babashka.fs/exec-paths) - Returns executable paths (using the <code>PATH</code> environment variable).
-    -  [`executable?`](#babashka.fs/executable?) - Returns true if <code>f</code> has is executable via [Files/isExecutable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isExecutable(java.nio.file.Path)).
-    -  [`exists?`](#babashka.fs/exists?) - Returns true if <code>f</code> exists via [Files/exists](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#exists(java.nio.file.Path,java.nio.file.LinkOption...)).
-    -  [`expand-home`](#babashka.fs/expand-home) - If <code>f</code> begins with a tilde (<code>~</code>), expand the tilde to the value of the <code>user.home</code> system property.
+    -  [`absolute?`](#babashka.fs/absolute?) - Returns <code>true</code> if <code>path</code> is absolute via [Path#isAbsolute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#isAbsolute()).
+    -  [`absolutize`](#babashka.fs/absolutize) - Returns absolute path for <code>path</code> via [Path#toAbsolutePath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toAbsolutePath()).
+    -  [`canonicalize`](#babashka.fs/canonicalize) - Returns canonical path for <code>path</code> via [File#getCanonicalPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getCanonicalPath()).
+    -  [`components`](#babashka.fs/components) - Returns a seq of paths for all components of <code>path</code>.
+    -  [`copy`](#babashka.fs/copy) - Copies <code>source-file</code> to <code>target-path</code> dir or file via [Files/copy](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#copy(java.nio.file.Path,java.nio.file.Path,java.nio.file.CopyOption...)).
+    -  [`copy-tree`](#babashka.fs/copy-tree) - Copies entire file tree from <code>source-dir</code> to <code>target-dir</code>.
+    -  [`create-dir`](#babashka.fs/create-dir) - Returns new <code>dir</code> created via [Files/createDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectory(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+    -  [`create-dirs`](#babashka.fs/create-dirs) - Returns <code>dir</code> after creating directories for <code>dir</code> via [Files/createDirectories](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectories(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+    -  [`create-file`](#babashka.fs/create-file) - Returns new empty <code>file</code> created via [Files/createFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createFile(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+    -  [`create-link`](#babashka.fs/create-link) - Returns a new hard <code>link</code> (directory entry) for an <code>existing-file</code> created via [Files/createLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createLink(java.nio.file.Path,java.nio.file.Path)).
+    -  [`create-sym-link`](#babashka.fs/create-sym-link) - Returns new symbolic <code>link</code> to <code>target-path</code> created via [Files/createSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createSymbolicLink(java.nio.file.Path,java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+    -  [`create-temp-dir`](#babashka.fs/create-temp-dir) - Returns path to directory created via [Files/createTempDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createTempDirectory(java.nio.file.Path,java.lang.String,java.nio.file.attribute.FileAttribute...)).
+    -  [`create-temp-file`](#babashka.fs/create-temp-file) - Returns path to empty file created via [Files/createTempFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createTempFile(java.nio.file.Path,java.lang.String,java.lang.String,java.nio.file.attribute.FileAttribute...)).
+    -  [`creation-time`](#babashka.fs/creation-time) - Returns creation time of <code>path</code> as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
+    -  [`cwd`](#babashka.fs/cwd) - Returns current working directory path.
+    -  [`delete`](#babashka.fs/delete) - Deletes <code>path</code> via [Files/delete](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#delete(java.nio.file.Path)).
+    -  [`delete-if-exists`](#babashka.fs/delete-if-exists) - Deletes <code>path</code> if it exists via [Files/deleteIfExists](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#deleteIfExists(java.nio.file.Path)).
+    -  [`delete-on-exit`](#babashka.fs/delete-on-exit) - Requests delete of <code>path</code> on exit via [File#deleteOnExit](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#deleteOnExit()).
+    -  [`delete-tree`](#babashka.fs/delete-tree) - Deletes the file tree at <code>root-path</code> using [<code>walk-file-tree</code>](#babashka.fs/walk-file-tree).
+    -  [`directory?`](#babashka.fs/directory?) - Returns <code>true</code> if <code>path</code> is a directory via [Files/isDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isDirectory(java.nio.file.Path,java.nio.file.LinkOption...)).
+    -  [`ends-with?`](#babashka.fs/ends-with?) - Returns <code>true</code> if <code>this-path</code> ends with <code>other-path</code> via [Path#endsWith](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#endsWith(java.nio.file.Path)).
+    -  [`exec-paths`](#babashka.fs/exec-paths) - Returns a vector of command search paths (from the <code>PATH</code> environment variable).
+    -  [`executable?`](#babashka.fs/executable?) - Returns <code>true</code> if <code>path</code> is executable via [Files/isExecutable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isExecutable(java.nio.file.Path)).
+    -  [`exists?`](#babashka.fs/exists?) - Returns <code>true</code> if <code>path</code> exists via [Files/exists](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#exists(java.nio.file.Path,java.nio.file.LinkOption...)).
+    -  [`expand-home`](#babashka.fs/expand-home) - Returns <code>path</code> replacing <code>~</code> (tilde) with home dir.
     -  [`extension`](#babashka.fs/extension) - Returns the extension of <code>path</code> via [<code>split-ext</code>](#babashka.fs/split-ext).
-    -  [`file`](#babashka.fs/file) - Coerces arg(s) into a <code>File</code>, combining multiple paths into one.
-    -  [`file-name`](#babashka.fs/file-name) - Returns the name of the file or directory via [File#getName](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getName()).
-    -  [`file-separator`](#babashka.fs/file-separator) - The system-dependent default name-separator character (as string).
-    -  [`file-time->instant`](#babashka.fs/file-time->instant) - Converts <code>ft</code> [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html) to an [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html).
-    -  [`file-time->millis`](#babashka.fs/file-time->millis) - Converts <code>ft</code> [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html) to epoch millis (long).
-    -  [`get-attribute`](#babashka.fs/get-attribute) - Return <code>attribute</code> for <code>path</code> via [Files/getAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getAttribute(java.nio.file.Path,java.lang.String,java.nio.file.LinkOption...)) Options: * [<code>:nofollow-links</code>](/README.md#nofollow-links).
-    -  [`glob`](#babashka.fs/glob) - Returns a vector of paths matching glob <code>pattern</code> (on path and filename) relative to <code>root</code> dir.
-    -  [`gunzip`](#babashka.fs/gunzip) - Extracts <code>gz-file</code> to <code>dest</code> dir.
-    -  [`gzip`](#babashka.fs/gzip) - Gzips <code>source-file</code> to <code>dir/out-file</code>.
-    -  [`hidden?`](#babashka.fs/hidden?) - Returns true if <code>f</code> is hidden via [Files/isHidden](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isHidden(java.nio.file.Path)).
-    -  [`home`](#babashka.fs/home) - With no arguments, returns the current value of the <code>user.home</code> system property as a <code>Path</code>.
-    -  [`instant->file-time`](#babashka.fs/instant->file-time) - Converts <code>instant</code> [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html) to a [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
-    -  [`last-modified-time`](#babashka.fs/last-modified-time) - Returns last modified time of <code>f</code> as a [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
-    -  [`list-dir`](#babashka.fs/list-dir) - Returns all paths in <code>dir</code> as vector.
-    -  [`list-dirs`](#babashka.fs/list-dirs) - Similar to list-dir but accepts multiple roots in <code>dirs</code> and returns the concatenated results.
-    -  [`match`](#babashka.fs/match) - Returns a vector of paths matching <code>pattern</code> (on path and filename) relative to <code>root</code> dir.
-    -  [`millis->file-time`](#babashka.fs/millis->file-time) - Converts epoch millis (long) to a [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
-    -  [`modified-since`](#babashka.fs/modified-since) - Returns seq of regular files (non-directories, non-symlinks) from <code>file-set</code> that were modified since the <code>anchor</code> path.
-    -  [`move`](#babashka.fs/move) - Move or rename dir or file <code>source</code> to <code>target</code> dir or file via [Files/move](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#move(java.nio.file.Path,java.nio.file.Path,java.nio.file.CopyOption...)).
-    -  [`normalize`](#babashka.fs/normalize) - Returns normalize <code>Path</code> for <code>f</code> via [Path#normalize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#normalize()).
-    -  [`owner`](#babashka.fs/owner) - Returns the owner of file <code>f</code> via [Files/getOwner](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getOwner(java.nio.file.Path,java.nio.file.LinkOption...)).
-    -  [`parent`](#babashka.fs/parent) - Returns parent of <code>f</code>.
-    -  [`path`](#babashka.fs/path) - Coerces arg(s) into a <code>Path</code>, combining multiple paths into one.
+    -  [`file`](#babashka.fs/file) - Returns <code>path</code>(s) coerced to a <code>File</code>, combining multiple paths into one.
+    -  [`file-name`](#babashka.fs/file-name) - Returns the name of the file or directory for <code>path</code> via [File#getName](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getName()).
+    -  [`file-separator`](#babashka.fs/file-separator) - The system-dependent default path component separator character (as string).
+    -  [`file-time->instant`](#babashka.fs/file-time->instant) - Returns [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html) <code>ft</code> as [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html).
+    -  [`file-time->millis`](#babashka.fs/file-time->millis) - Returns [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html) <code>ft</code> as epoch milliseconds (long).
+    -  [`get-attribute`](#babashka.fs/get-attribute) - Returns <code>attribute</code> for <code>path</code> via [Files/getAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getAttribute(java.nio.file.Path,java.lang.String,java.nio.file.LinkOption...)).
+    -  [`glob`](#babashka.fs/glob) - Returns a vector of paths matching glob <code>pattern</code> (on path and filename) relative to <code>root-dir</code>.
+    -  [`gunzip`](#babashka.fs/gunzip) - Extracts <code>gz-file</code> to <code>target-dir</code>.
+    -  [`gzip`](#babashka.fs/gzip) - Gzips <code>source-file</code> to <code>:dir</code>/<code>:out-file</code>.
+    -  [`hidden?`](#babashka.fs/hidden?) - Returns <code>true</code> if <code>path</code> is hidden via [Files/isHidden](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isHidden(java.nio.file.Path)).
+    -  [`home`](#babashka.fs/home) - Returns home dir path.
+    -  [`instant->file-time`](#babashka.fs/instant->file-time) - Returns [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html) <code>instant</code> as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
+    -  [`last-modified-time`](#babashka.fs/last-modified-time) - Returns last modified time of <code>path</code> as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
+    -  [`list-dir`](#babashka.fs/list-dir) - Returns a vector of all paths in <code>dir</code>.
+    -  [`list-dirs`](#babashka.fs/list-dirs) - Similar to [<code>list-dir</code>](#babashka.fs/list-dir) but accepts multiple roots in <code>dirs</code> and returns the concatenated results.
+    -  [`match`](#babashka.fs/match) - Returns a vector of paths matching <code>pattern</code> (on path and filename) relative to <code>root-dir</code>.
+    -  [`millis->file-time`](#babashka.fs/millis->file-time) - Returns epoch milliseconds (long) as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
+    -  [`modified-since`](#babashka.fs/modified-since) - Returns seq of regular files (non-directories, non-symlinks) from <code>path-set</code> that were modified since the <code>anchor-path</code>.
+    -  [`move`](#babashka.fs/move) - Moves or renames dir or file at <code>source-path</code> to <code>target-path</code> dir or file via [Files/move](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#move(java.nio.file.Path,java.nio.file.Path,java.nio.file.CopyOption...)).
+    -  [`normalize`](#babashka.fs/normalize) - Returns normalized path for <code>path</code> via [Path#normalize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#normalize()).
+    -  [`owner`](#babashka.fs/owner) - Returns the owner of <code>path</code> via [Files/getOwner](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getOwner(java.nio.file.Path,java.nio.file.LinkOption...)).
+    -  [`parent`](#babashka.fs/parent) - Returns parent path of <code>path</code> via [Paths/getParent](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#getParent()).
+    -  [`path`](#babashka.fs/path) - Returns <code>path</code>(s) coerced to a <code>Path</code>, combining multiple paths into one.
     -  [`path-separator`](#babashka.fs/path-separator) - The system-dependent path-separator character (as string).
-    -  [`posix->str`](#babashka.fs/posix->str) - Converts a set of <code>PosixFilePermission</code> <code>p</code> to a string.
-    -  [`posix-file-permissions`](#babashka.fs/posix-file-permissions) - Returns posix file permissions for <code>f</code>.
-    -  [`read-all-bytes`](#babashka.fs/read-all-bytes) - Returns contents of file <code>f</code> as byte array via [Files/readAllBytes](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllBytes(java.nio.file.Path)).
-    -  [`read-all-lines`](#babashka.fs/read-all-lines) - Read all lines from a file <code>f</code> via [Files/readAllLines](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllLines(java.nio.file.Path,java.nio.charset.Charset)).
-    -  [`read-attributes`](#babashka.fs/read-attributes) - Same as [<code>read-attributes*</code>](#babashka.fs/read-attributes*) but turns <code>attributes</code> for <code>path</code> into a map and keywordizes keys.
-    -  [`read-attributes*`](#babashka.fs/read-attributes*) - Reads <code>attributes</code> for <code>path</code> via [Files/readAttributes](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAttributes(java.nio.file.Path,java.lang.Class,java.nio.file.LinkOption...)).
-    -  [`read-link`](#babashka.fs/read-link) - Reads the target of a symbolic link <code>path</code> via [Files/readSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readSymbolicLink(java.nio.file.Path)).
-    -  [`readable?`](#babashka.fs/readable?) - Returns true if <code>f</code> is readable via [Files/isReadable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isReadable(java.nio.file.Path)).
-    -  [`real-path`](#babashka.fs/real-path) - Converts <code>f</code> into real <code>Path</code> via [Path#toRealPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toRealPath(java.nio.file.LinkOption...)).
-    -  [`regular-file?`](#babashka.fs/regular-file?) - Returns true if <code>f</code> is a regular file, using [Files/isRegularFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isRegularFile(java.nio.file.Path,java.nio.file.LinkOption...)).
-    -  [`relative?`](#babashka.fs/relative?) - Returns true if <code>f</code> represents a relative path (in other words, is not [<code>absolute?</code>](#babashka.fs/absolute?)).
-    -  [`relativize`](#babashka.fs/relativize) - Returns relative <code>Path</code> by comparing <code>this</code> with <code>other</code> via [Path#relativize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#relativize(java.nio.file.Path)).
-    -  [`root`](#babashka.fs/root) - Returns <code>root</code> for <code>path</code> as <code>Path</code>, or <code>nil</code> via [Path#getRoot](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#getRoot()).
-    -  [`same-file?`](#babashka.fs/same-file?) - Returns <code>true</code> if <code>this</code> is the same file as <code>other</code> via [Files/isSamefile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isSameFile(java.nio.file.Path,java.nio.file.Path)).
-    -  [`set-attribute`](#babashka.fs/set-attribute) - Set <code>attribute</code> for <code>path</code> to <code>value</code> via [Files/setAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#setAttribute(java.nio.file.Path,java.lang.String,java.lang.Object,java.nio.file.LinkOption...)).
-    -  [`set-creation-time`](#babashka.fs/set-creation-time) - Sets creation time of <code>f</code> to time (<code>epoch millis</code> or [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)).
-    -  [`set-last-modified-time`](#babashka.fs/set-last-modified-time) - Sets last modified time of <code>f</code> to <code>time</code> (<code>epoch millis</code> or [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)).
-    -  [`set-posix-file-permissions`](#babashka.fs/set-posix-file-permissions) - Sets <code>posix-file-permissions</code> on <code>f</code>.
-    -  [`size`](#babashka.fs/size) - Returns the size of a file (in bytes).
-    -  [`split-ext`](#babashka.fs/split-ext) - Splits <code>path</code> on extension.
-    -  [`split-paths`](#babashka.fs/split-paths) - Splits a <code>joined-paths</code> list given as a string joined by the OS-specific [<code>path-separator</code>](#babashka.fs/path-separator) into a vec of paths.
-    -  [`starts-with?`](#babashka.fs/starts-with?) - Returns <code>true</code> if path <code>this</code> starts with path <code>other</code> via [Path#startsWith](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#startsWith(java.nio.file.Path)).
-    -  [`str->posix`](#babashka.fs/str->posix) - Converts a string <code>s</code> to a set of <code>PosixFilePermission</code>.
-    -  [`strip-ext`](#babashka.fs/strip-ext) - Strips extension for <code>path</code> via [<code>split-ext</code>](#babashka.fs/split-ext).
-    -  [`sym-link?`](#babashka.fs/sym-link?) - Determines if <code>f</code> is a symbolic link via [Files/isSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isSymbolicLink(java.nio.file.Path)).
+    -  [`posix->str`](#babashka.fs/posix->str) - Returns permissions string, like <code>&quot;rwx------&quot;</code>, for a set of <code>PosixFilePermission</code> <code>p</code>.
+    -  [`posix-file-permissions`](#babashka.fs/posix-file-permissions) - Returns a set of <code>PosixFilePermissions</code> for <code>path</code> via [Files/getPosixFilePermissions](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getPosixFilePermissions(java.nio.file.Path,java.nio.file.LinkOption...)).
+    -  [`read-all-bytes`](#babashka.fs/read-all-bytes) - Returns contents of <code>file</code> as byte array via [Files/readAllBytes](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllBytes(java.nio.file.Path)).
+    -  [`read-all-lines`](#babashka.fs/read-all-lines) - Return contents of <code>file</code> as a vector of lines via [Files/readAllLines](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllLines(java.nio.file.Path,java.nio.charset.Charset)).
+    -  [`read-attributes`](#babashka.fs/read-attributes) - Same as [<code>read-attributes*</code>](#babashka.fs/read-attributes*) but returns requested <code>attributes</code> for <code>path</code> as a map with keywordized attribute keys.
+    -  [`read-attributes*`](#babashka.fs/read-attributes*) - Returns requested <code>attributes</code> for <code>path</code> via [Files/readAttributes](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAttributes(java.nio.file.Path,java.lang.Class,java.nio.file.LinkOption...)).
+    -  [`read-link`](#babashka.fs/read-link) - Returns the immediate target of <code>sym-link-path</code> via [Files/readSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readSymbolicLink(java.nio.file.Path)).
+    -  [`readable?`](#babashka.fs/readable?) - Returns <code>true</code> if <code>path</code> is readable via [Files/isReadable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isReadable(java.nio.file.Path)).
+    -  [`real-path`](#babashka.fs/real-path) - Returns real path for <code>path</code> via [Path#toRealPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toRealPath(java.nio.file.LinkOption...)).
+    -  [`regular-file?`](#babashka.fs/regular-file?) - Returns <code>true</code> if <code>path</code> is a regular file via [Files/isRegularFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isRegularFile(java.nio.file.Path,java.nio.file.LinkOption...)).
+    -  [`relative?`](#babashka.fs/relative?) - Returns <code>true</code> if <code>path</code> is relative (in other words, is not [<code>absolute?</code>](#babashka.fs/absolute?)).
+    -  [`relativize`](#babashka.fs/relativize) - Returns <code>other-path</code> relative to <code>base-path</code> via [Path#relativize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#relativize(java.nio.file.Path)).
+    -  [`root`](#babashka.fs/root) - Returns root path for <code>path</code>, or <code>nil</code>, via [Path#getRoot](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#getRoot()).
+    -  [`same-file?`](#babashka.fs/same-file?) - Returns <code>true</code> if <code>this-path</code> is the same file as <code>other-path</code> via [Files/isSamefile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isSameFile(java.nio.file.Path,java.nio.file.Path)).
+    -  [`set-attribute`](#babashka.fs/set-attribute) - Sets <code>attribute</code> for <code>path</code> to <code>value</code> via [Files/setAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#setAttribute(java.nio.file.Path,java.lang.String,java.lang.Object,java.nio.file.LinkOption...)).
+    -  [`set-creation-time`](#babashka.fs/set-creation-time) - Sets creation <code>time</code> of <code>path</code>.
+    -  [`set-last-modified-time`](#babashka.fs/set-last-modified-time) - Sets last modified <code>time</code> of <code>path</code>.
+    -  [`set-posix-file-permissions`](#babashka.fs/set-posix-file-permissions) - Sets <code>posix-file-permissions</code> on <code>path</code> via [Files/setPosixFilePermissions](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#setPosixFilePermissions(java.nio.file.Path,java.util.Set)).
+    -  [`size`](#babashka.fs/size) - Returns the size of <code>path</code> in bytes.
+    -  [`split-ext`](#babashka.fs/split-ext) - Returns <code>path</code> split on extension.
+    -  [`split-paths`](#babashka.fs/split-paths) - Returns a vector of paths from paths in <code>joined-paths</code> string.
+    -  [`starts-with?`](#babashka.fs/starts-with?) - Returns <code>true</code> if <code>this-path</code> starts with <code>other-path</code> via [Path#startsWith](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#startsWith(java.nio.file.Path)).
+    -  [`str->posix`](#babashka.fs/str->posix) - Returns a set of <code>PosixFilePermission</code> for permissions string <code>s</code>.
+    -  [`strip-ext`](#babashka.fs/strip-ext) - Returns <code>path</code> with extension stripped via [<code>split-ext</code>](#babashka.fs/split-ext).
+    -  [`sym-link?`](#babashka.fs/sym-link?) - Returns <code>true</code> if <code>path</code> is a symbolic link via [Files/isSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isSymbolicLink(java.nio.file.Path)).
     -  [`temp-dir`](#babashka.fs/temp-dir) - Returns <code>java.io.tmpdir</code> property as path.
-    -  [`touch`](#babashka.fs/touch) - Update last modified time of <code>path</code> to <code>:time</code>, creating <code>path</code> as file if it does not exist.
-    -  [`unixify`](#babashka.fs/unixify) - Returns path as string with Unix-style file separators (<code>/</code>).
-    -  [`unzip`](#babashka.fs/unzip) - Unzips <code>zip-file</code> to <code>dest</code> directory (default <code>&quot;.&quot;</code>).
-    -  [`update-file`](#babashka.fs/update-file) - Updates the contents of text file <code>path</code> using <code>f</code> applied to old contents and <code>xs</code>.
-    -  [`walk-file-tree`](#babashka.fs/walk-file-tree) - Walks <code>f</code> using [Files/walkFileTree](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#walkFileTree(java.nio.file.Path,java.util.Set,int,java.nio.file.FileVisitor)).
-    -  [`which`](#babashka.fs/which) - Returns <code>Path</code> to first executable <code>program</code> found in <code>:paths</code> <code>opt</code>, similar to the <code>which</code> Unix command.
-    -  [`which-all`](#babashka.fs/which-all) - Returns every <code>Path</code> to <code>program</code> found in ([<code>exec-paths</code>](#babashka.fs/exec-paths)).
-    -  [`windows?`](#babashka.fs/windows?) - Returns true if OS is Windows.
-    -  [`with-temp-dir`](#babashka.fs/with-temp-dir) - Evaluates body with binding-name bound to the result of <code>(create-temp-dir options)</code>.
-    -  [`writable?`](#babashka.fs/writable?) - Returns true if <code>f</code> is writable via [Files/isWritable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isWritable(java.nio.file.Path)).
-    -  [`write-bytes`](#babashka.fs/write-bytes) - Writes <code>bytes</code> to <code>path</code> via [Files/write](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#write(java.nio.file.Path,byte%5B%5D,java.nio.file.OpenOption...)).
-    -  [`write-lines`](#babashka.fs/write-lines) - Writes <code>lines</code>, a seqable of strings to <code>path</code> via [Files/write](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#write(java.nio.file.Path,java.lang.Iterable,java.nio.charset.Charset,java.nio.file.OpenOption...)).
-    -  [`xdg-cache-home`](#babashka.fs/xdg-cache-home) - Path representing the base directory relative to which user-specific non-essential data files should be stored as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
-    -  [`xdg-config-home`](#babashka.fs/xdg-config-home) - Path representing the base directory relative to which user-specific configuration files should be stored as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
-    -  [`xdg-data-home`](#babashka.fs/xdg-data-home) - Path representing the base directory relative to which user-specific data files should be stored as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
-    -  [`xdg-state-home`](#babashka.fs/xdg-state-home) - Path representing the base directory relative to which user-specific state files should be stored as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
-    -  [`zip`](#babashka.fs/zip) - Zips entry or <code>entries</code> into <code>zip-file</code>.
+    -  [`touch`](#babashka.fs/touch) - Update last modified time of <code>path</code> to <code>:time</code>, creating <code>path</code> as a file if it does not exist.
+    -  [`unixify`](#babashka.fs/unixify) - Returns <code>path</code> as string with Unix-style file separators (<code>/</code>).
+    -  [`unzip`](#babashka.fs/unzip) - Unzips <code>zip-file</code> to <code>target-dir</code> (default <code>&quot;.&quot;</code>).
+    -  [`update-file`](#babashka.fs/update-file) - Updates the contents of text <code>file</code> with result of applying function <code>f</code> with old contents and args <code>xs</code>.
+    -  [`walk-file-tree`](#babashka.fs/walk-file-tree) - Walks <code>path</code> via [Files/walkFileTree](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#walkFileTree(java.nio.file.Path,java.util.Set,int,java.nio.file.FileVisitor)).
+    -  [`which`](#babashka.fs/which) - Returns path to first executable <code>program</code> found in <code>:paths</code>, similar to the <code>which</code> Unix command.
+    -  [`which-all`](#babashka.fs/which-all) - Returns a vector of every path to <code>program</code> found in ([<code>exec-paths</code>](#babashka.fs/exec-paths)).
+    -  [`windows?`](#babashka.fs/windows?) - Returns <code>true</code> if OS is Windows.
+    -  [`with-temp-dir`](#babashka.fs/with-temp-dir) - Evaluates body with <code>temp-dir</code> bound to the result of <code>(create-temp-dir opts)</code>.
+    -  [`writable?`](#babashka.fs/writable?) - Returns <code>true</code> if <code>path</code> is writable via [Files/isWritable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isWritable(java.nio.file.Path)).
+    -  [`write-bytes`](#babashka.fs/write-bytes) - Writes <code>bytes</code> to <code>file</code> via [Files/write](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#write(java.nio.file.Path,byte%5B%5D,java.nio.file.OpenOption...)).
+    -  [`write-lines`](#babashka.fs/write-lines) - Writes <code>lines</code>, a seqable of strings, to <code>file</code> via [Files/write](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#write(java.nio.file.Path,java.lang.Iterable,java.nio.charset.Charset,java.nio.file.OpenOption...)).
+    -  [`xdg-cache-home`](#babashka.fs/xdg-cache-home) - Returns path to user-specific non-essential data as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+    -  [`xdg-config-home`](#babashka.fs/xdg-config-home) - Returns path to user-specific configuration files as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+    -  [`xdg-data-home`](#babashka.fs/xdg-data-home) - Returns path to user-specific data files as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+    -  [`xdg-state-home`](#babashka.fs/xdg-state-home) - Returns path to user-specific state files as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+    -  [`zip`](#babashka.fs/zip) - Zips <code>path-or-paths</code> into <code>zip-file</code>.
 
 -----
 # <a name="babashka.fs">babashka.fs</a>
@@ -104,139 +104,141 @@
 
 ## <a name="babashka.fs/absolute?">`absolute?`</a>
 ``` clojure
-(absolute? f)
+(absolute? path)
 ```
 Function.
 
-Returns true if `f` represents an absolute path via [Path#isAbsolute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#isAbsolute()).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L135-L137">Source</a></sub></p>
+Returns `true` if `path` is absolute via [Path#isAbsolute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#isAbsolute()).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L137-L139">Source</a></sub></p>
 
 ## <a name="babashka.fs/absolutize">`absolutize`</a>
 ``` clojure
-(absolutize f)
+(absolutize path)
 ```
 Function.
 
-Converts `f` into an absolute `Path` via [Path#toAbsolutePath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toAbsolutePath()).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L177-L179">Source</a></sub></p>
+Returns absolute path for `path` via [Path#toAbsolutePath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toAbsolutePath()).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L179-L181">Source</a></sub></p>
 
 ## <a name="babashka.fs/canonicalize">`canonicalize`</a>
 ``` clojure
-(canonicalize f)
-(canonicalize f {:keys [:nofollow-links]})
+(canonicalize path)
+(canonicalize path {:keys [:nofollow-links]})
 ```
 Function.
 
-Returns the canonical `Path` for `f` via [File#getCanonicalPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getCanonicalPath()).
+Returns canonical path for `path` via [File#getCanonicalPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getCanonicalPath()).
 
 Options:
-* [`:nofollow-links`](/README.md#nofollow-links), when set, falls back on [`absolutize`](#babashka.fs/absolutize) + [`normalize`](#babashka.fs/normalize).
+* [`:nofollow-links`](/README.md#nofollow-links) - when set, falls back on [`absolutize`](#babashka.fs/absolutize) + [`normalize`](#babashka.fs/normalize).
 
 This function can be used as an alternative to [`real-path`](#babashka.fs/real-path) which requires files to exist.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L191-L202">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L197-L208">Source</a></sub></p>
 
 ## <a name="babashka.fs/components">`components`</a>
 ``` clojure
-(components f)
+(components path)
 ```
 Function.
 
-Returns a seq of all components of `f` as paths.
+Returns a seq of paths for all components of `path`.
 i.e.: split on the [`file-separator`](#babashka.fs/file-separator).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L171-L175">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L173-L177">Source</a></sub></p>
 
 ## <a name="babashka.fs/copy">`copy`</a>
 ``` clojure
-(copy src dest)
-(copy src dest {:keys [replace-existing copy-attributes nofollow-links]})
+(copy source-file target-path)
+(copy source-file target-path {:keys [replace-existing copy-attributes nofollow-links]})
 ```
 Function.
 
-Copies `src` file to `dest` dir or file using [Files/copy](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#copy(java.nio.file.Path,java.nio.file.Path,java.nio.file.CopyOption...)).
+Copies `source-file` to `target-path` dir or file via [Files/copy](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#copy(java.nio.file.Path,java.nio.file.Path,java.nio.file.CopyOption...)).
 
 Options:
 * `:replace-existing`
 * `:copy-attributes`
-* [`:nofollow-links`](/README.md#nofollow-links) (used to determine to copy symbolic link itself or not).
-Returns `dest` as path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L458-L478">Source</a></sub></p>
+* [`:nofollow-links`](/README.md#nofollow-links) - used to determine to copy symbolic link itself or not.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L465-L484">Source</a></sub></p>
 
 ## <a name="babashka.fs/copy-tree">`copy-tree`</a>
 ``` clojure
-(copy-tree src dest)
-(copy-tree src dest {:keys [:replace-existing :copy-attributes :nofollow-links], :as opts})
+(copy-tree source-dir target-dir)
+(copy-tree source-dir target-dir {:keys [:replace-existing :copy-attributes :nofollow-links], :as opts})
 ```
 Function.
 
-Copies entire file tree from `src` to `dest`. Creates `dest` if needed
-using [`create-dirs`](#babashka.fs/create-dirs), passing it the `:posix-file-permissions`
-option. Supports same options as [`copy`](#babashka.fs/copy).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L579-L632">Source</a></sub></p>
+Copies entire file tree from `source-dir` to `target-dir`. Creates `target-dir` if needed.
+ 
+Options:
+* same as [`copy`](#babashka.fs/copy)
+* `:posix-file-permissions` - string format unix-like system permissions passed to [`create-dirs`](#babashka.fs/create-dirs) when creating `target-dir`.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L595-L650">Source</a></sub></p>
 
 ## <a name="babashka.fs/create-dir">`create-dir`</a>
 ``` clojure
-(create-dir path)
-(create-dir path {:keys [:posix-file-permissions]})
+(create-dir dir)
+(create-dir dir {:keys [:posix-file-permissions]})
 ```
 Function.
 
-Creates dir using [Files/createDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectory(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+Returns new `dir` created via [Files/createDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectory(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
 Does not create parents.
 
-Returns created directory as `Path`.
-
 Options:
-* `:posix-file-permissions` permission for unix-like systems, affected by [umask](/README.md#umask)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L513-L525">Source</a></sub></p>
+* `:posix-file-permissions` - string format for unix-like system permissions for `dir`, as described in [`str->posix`](#babashka.fs/str->posix).
+Affected by [umask](/README.md#umask).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L523-L534">Source</a></sub></p>
 
 ## <a name="babashka.fs/create-dirs">`create-dirs`</a>
 ``` clojure
-(create-dirs path)
-(create-dirs path {:keys [:posix-file-permissions]})
+(create-dirs dir)
+(create-dirs dir {:keys [:posix-file-permissions]})
 ```
 Function.
 
-Creates directories for `path` using [Files/createDirectories](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectories(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+Returns `dir` after creating directories for `dir` via [Files/createDirectories](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectories(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
 Also creates parents if needed.
-Doesn't throw an exception if the dirs exist already. Similar to `mkdir -p`
-
+Does not throw an exception if the dirs exist already. Similar to `mkdir -p` shell command.
+  
 Options:
-* `:posix-file-permissions` permission for unix-like systems, affected by [umask](/README.md#umask)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L527-L539">Source</a></sub></p>
+* `:posix-file-permissions` - string format for unix-like system permissions for `dir`, as described in [`str->posix`](#babashka.fs/str->posix).
+Affected by [umask](/README.md#umask).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L536-L549">Source</a></sub></p>
 
 ## <a name="babashka.fs/create-file">`create-file`</a>
 ``` clojure
-(create-file path)
-(create-file path {:keys [:posix-file-permissions]})
+(create-file file)
+(create-file file {:keys [:posix-file-permissions]})
 ```
 Function.
 
-Creates empty file at `path` using [Files/createFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createFile(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+Returns new empty `file` created via [Files/createFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createFile(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
 
 Options:
-* `:posix-file-permissions` string format for posix file permissions is described in the [`str->posix`](#babashka.fs/str->posix) docstring.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L792-L801">Source</a></sub></p>
+* `:posix-file-permissions` - string format for unix-like system permissions for `file`, as described in [`str->posix`](#babashka.fs/str->posix).
+Affected by [umask](/README.md#umask).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L810-L820">Source</a></sub></p>
 
 ## <a name="babashka.fs/create-link">`create-link`</a>
 ``` clojure
-(create-link link existing)
+(create-link link existing-file)
 ```
 Function.
 
-Create a new `link` (directory entry) for an `existing` file via [Files/createLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createLink(java.nio.file.Path,java.nio.file.Path)).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L736-L741">Source</a></sub></p>
+Returns a new hard `link` (directory entry) for an `existing-file` created via [Files/createLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createLink(java.nio.file.Path,java.nio.file.Path)).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L752-L757">Source</a></sub></p>
 
 ## <a name="babashka.fs/create-sym-link">`create-sym-link`</a>
 ``` clojure
-(create-sym-link link target)
+(create-sym-link link target-path)
 ```
 Function.
 
-Create a symbolic `link` to `target` via [Files/createSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createSymbolicLink(java.nio.file.Path,java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+Returns new symbolic `link` to `target-path` created via [Files/createSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createSymbolicLink(java.nio.file.Path,java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
 
-As of this writing, JDKs do not recognize empty-string `target` `""` as the cwd.
-Consider instead using a `target` of `"."` to link to the cwd.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L725-L734">Source</a></sub></p>
+As of this writing, JDKs do not recognize empty-string `target-path` `""` as the cwd.
+Consider instead using a `target-path` of `"."` to link to the cwd.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L741-L750">Source</a></sub></p>
 
 ## <a name="babashka.fs/create-temp-dir">`create-temp-dir`</a>
 ``` clojure
@@ -245,22 +247,21 @@ Consider instead using a `target` of `"."` to link to the cwd.
 ```
 Function.
 
-Creates a directory using [Files/createTempDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createTempDirectory(java.nio.file.Path,java.lang.String,java.nio.file.attribute.FileAttribute...)).
+Returns path to directory created via [Files/createTempDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createTempDirectory(java.nio.file.Path,java.lang.String,java.nio.file.attribute.FileAttribute...)).
 
 This function does not set up any automatic deletion of the directories it
 creates. See [`with-temp-dir`](#babashka.fs/with-temp-dir) for that functionality.
 
 Options:
-* `:dir`: Directory in which to create the new directory. Defaults to default
+* `:dir` - directory in which to create the new directory. Defaults to default
 system temp dir (e.g. `/tmp`); see [`temp-dir`](#babashka.fs/temp-dir). Must already exist.
-* `:prefix`: Provided as a hint to the process that generates the name of the
+* `:prefix` - provided as a hint to the process that generates the name of the
 new directory. In most cases, this will be the beginning of the new directory
 name. Defaults to a random (v4) UUID.
-* `:posix-file-permissions`: The new directory will be created with these
-permissions, given as a String as described in [`str->posix`](#babashka.fs/str->posix). If not
-specified, uses the file system default permissions for new directories.
+* `:posix-file-permissions` - string format unix-like system permissions as described in [`str->posix`](#babashka.fs/str->posix) for new directory.
+If not specified, uses the file system default permissions for new directories.
 Affected by [umask](/README.md#umask).
-* :warning: `:path` **[DEPRECATED]** Previous name for `:dir`, kept
+* :warning: `:path` - **[DEPRECATED]** previous name for `:dir`, kept
 for backwards compatibility. If both `:path` and `:dir` are given (don't do
 that!), `:dir` is used.
 
@@ -269,7 +270,7 @@ Examples:
 * `(create-temp-dir {:posix-file-permissions "rwx------"})`
 * `(create-temp-dir {:dir (path (cwd) "_workdir") :prefix "process-1-"})`
   
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L639-L676">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L657-L693">Source</a></sub></p>
 
 ## <a name="babashka.fs/create-temp-file">`create-temp-file`</a>
 ``` clojure
@@ -278,25 +279,24 @@ Examples:
 ```
 Function.
 
-Creates an empty file using [Files/createTempFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createTempFile(java.nio.file.Path,java.lang.String,java.lang.String,java.nio.file.attribute.FileAttribute...)).
+Returns path to empty file created via [Files/createTempFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createTempFile(java.nio.file.Path,java.lang.String,java.lang.String,java.nio.file.attribute.FileAttribute...)).
 
 This function does not set up any automatic deletion of the files it
 creates. Create the file in a [`with-temp-dir`](#babashka.fs/with-temp-dir) for that functionality.
 
 Options:
-* `:dir`: Directory in which to create the new file. Defaults to default
+* `:dir` - directory in which to create the new file. Defaults to default
 system temp dir (e.g. `/tmp`); see [`temp-dir`](#babashka.fs/temp-dir). Must already exist.
-* `:prefix`: Provided as a hint to the process that generates the name of the
+* `:prefix` - provided as a hint to the process that generates the name of the
 new file. In most cases, this will be the beginning of the new file name.
 Defaults to a random (v4) UUID.
-* `:suffix`: Provided as a hint to the process that generates the name of the
+* `:suffix` - provided as a hint to the process that generates the name of the
 new file. In most cases, this will be the end of the new file name.
 Defaults to a random (v4) UUID.
-* `:posix-file-permissions`: The new file will be created with these
-permissions, given as a String as described in [`str->posix`](#babashka.fs/str->posix). If not
-specified, uses the file system default permissions for new files.
+* `:posix-file-permissions` - string format unix-like system permissions for new file, as described in [`str->posix`](#babashka.fs/str->posix).
+If not specified, uses the file system default permissions for new files.
 Affected by [umask](/README.md#umask).
-* :warning: `:path` **[DEPRECATED]** Previous name for `:dir`, kept
+* :warning: `:path` - **[DEPRECATED]** Previous name for `:dir`, kept
 for backwards compatibility. If both `:path` and `:dir` are given (don't do
 that!), `:dir` is used.
 
@@ -305,19 +305,21 @@ Examples:
 * `(create-temp-file {:posix-file-permissions "rw-------"})`
 * `(create-temp-file {:dir (path (cwd) "_workdir") :prefix "process-1-" :suffix "-queue"})`
   
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L678-L723">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L695-L739">Source</a></sub></p>
 
 ## <a name="babashka.fs/creation-time">`creation-time`</a>
 ``` clojure
-(creation-time f)
-(creation-time f {:keys [nofollow-links], :as opts})
+(creation-time path)
+(creation-time path {:keys [nofollow-links], :as opts})
 ```
 Function.
 
-Returns creation time of `f` as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
+Returns creation time of `path` as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
 
 See [README notes](/README.md#creation-time) for some details on behaviour.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L973-L980">Source</a></sub></p>
+
+See also: [`set-creation-time`](#babashka.fs/set-creation-time), [`last-modified-time`](#babashka.fs/last-modified-time), [`file-time->instant`](#babashka.fs/file-time->instant), [`file-time->millis`](#babashka.fs/file-time->millis)
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1007-L1016">Source</a></sub></p>
 
 ## <a name="babashka.fs/cwd">`cwd`</a>
 ``` clojure
@@ -325,75 +327,77 @@ See [README notes](/README.md#creation-time) for some details on behaviour.
 ```
 Function.
 
-Returns current working directory as `Path`
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1428-L1431">Source</a></sub></p>
+Returns current working directory path.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1488-L1491">Source</a></sub></p>
 
 ## <a name="babashka.fs/delete">`delete`</a>
 ``` clojure
-(delete f)
+(delete path)
 ```
 Function.
 
-Deletes `f` using [Files/delete](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#delete(java.nio.file.Path)).
+Deletes `path` via [Files/delete](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#delete(java.nio.file.Path)).
 Returns `nil` if the delete was successful,
 throws otherwise. Does not follow symlinks.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L749-L756">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L765-L772">Source</a></sub></p>
 
 ## <a name="babashka.fs/delete-if-exists">`delete-if-exists`</a>
 ``` clojure
-(delete-if-exists f)
+(delete-if-exists path)
 ```
 Function.
 
-Deletes `f` if it exists via [Files/deleteIfExists](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#deleteIfExists(java.nio.file.Path)).
+Deletes `path` if it exists via [Files/deleteIfExists](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#deleteIfExists(java.nio.file.Path)).
 Returns `true` if the delete was successful,
-`false` if `f` didn't exist. Does not follow symlinks.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L758-L763">Source</a></sub></p>
+`false` if `path` didn't exist. Does not follow symlinks.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L774-L779">Source</a></sub></p>
 
 ## <a name="babashka.fs/delete-on-exit">`delete-on-exit`</a>
 ``` clojure
-(delete-on-exit f)
+(delete-on-exit path)
 ```
 Function.
 
-Requests delete of file `f` on exit via [File#deleteOnExit](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#deleteOnExit()).
-Returns `f` unaltered.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L837-L842">Source</a></sub></p>
+Requests delete of `path` on exit via [File#deleteOnExit](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#deleteOnExit()).
+Returns `path`.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L857-L862">Source</a></sub></p>
 
 ## <a name="babashka.fs/delete-tree">`delete-tree`</a>
 ``` clojure
-(delete-tree root)
-(delete-tree root {:keys [force]})
+(delete-tree root-path)
+(delete-tree root-path {:keys [force]})
 ```
 Function.
 
-Deletes a file tree `root` using [`walk-file-tree`](#babashka.fs/walk-file-tree). Similar to `rm -rf`. Does not follow symlinks.
-`force` ensures read-only directories/files are deleted. Similar to `chmod -R +wx` + `rm -rf`
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L770-L790">Source</a></sub></p>
+Deletes the file tree at `root-path` using [`walk-file-tree`](#babashka.fs/walk-file-tree). Similar to `rm -rf` shell command. Does not follow symlinks.
+
+Options:
+* `:force` - if `true` forces deletion of read-only files/directories. Similar to `chmod -R +wx` + `rm -rf` shell commands.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L786-L808">Source</a></sub></p>
 
 ## <a name="babashka.fs/directory?">`directory?`</a>
 ``` clojure
-(directory? f)
-(directory? f {:keys [:nofollow-links]})
+(directory? path)
+(directory? path {:keys [:nofollow-links]})
 ```
 Function.
 
-Returns true if `f` is a directory, using [Files/isDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isDirectory(java.nio.file.Path,java.nio.file.LinkOption...)).
+Returns `true` if `path` is a directory via [Files/isDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isDirectory(java.nio.file.Path,java.nio.file.LinkOption...)).
 
 Options:
 * [`:nofollow-links`](/README.md#nofollow-links)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L112-L120">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L114-L122">Source</a></sub></p>
 
 ## <a name="babashka.fs/ends-with?">`ends-with?`</a>
 ``` clojure
-(ends-with? this other)
+(ends-with? this-path other-path)
 ```
 Function.
 
-Returns `true` if path `this` ends with path `other` via [Path#endsWith](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#endsWith(java.nio.file.Path)).
+Returns `true` if `this-path` ends with `other-path` via [Path#endsWith](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#endsWith(java.nio.file.Path)).
 
 See also: [`starts-with?`](#babashka.fs/starts-with?)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L572-L577">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L588-L593">Source</a></sub></p>
 
 ## <a name="babashka.fs/exec-paths">`exec-paths`</a>
 ``` clojure
@@ -401,46 +405,50 @@ See also: [`starts-with?`](#babashka.fs/starts-with?)
 ```
 Function.
 
-Returns executable paths (using the `PATH` environment variable). Same
+Returns a vector of command search paths (from the `PATH` environment variable). Same
 as `(split-paths (System/getenv "PATH"))`.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1067-L1071">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1116-L1120">Source</a></sub></p>
 
 ## <a name="babashka.fs/executable?">`executable?`</a>
 ``` clojure
-(executable? f)
+(executable? path)
 ```
 Function.
 
-Returns true if `f` has is executable via [Files/isExecutable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isExecutable(java.nio.file.Path)).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L139-L141">Source</a></sub></p>
+Returns `true` if `path` is executable via [Files/isExecutable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isExecutable(java.nio.file.Path)).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L141-L143">Source</a></sub></p>
 
 ## <a name="babashka.fs/exists?">`exists?`</a>
 ``` clojure
-(exists? f)
-(exists? f {:keys [:nofollow-links]})
+(exists? path)
+(exists? path {:keys [:nofollow-links]})
 ```
 Function.
 
-Returns true if `f` exists via [Files/exists](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#exists(java.nio.file.Path,java.nio.file.LinkOption...)).
+Returns `true` if `path` exists via [Files/exists](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#exists(java.nio.file.Path,java.nio.file.LinkOption...)).
 
 Options:
 * [`:nofollow-links`](/README.md#nofollow-links)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L155-L167">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L157-L169">Source</a></sub></p>
 
 ## <a name="babashka.fs/expand-home">`expand-home`</a>
 ``` clojure
-(expand-home f)
+(expand-home path)
 ```
 Function.
 
-If `f` begins with a tilde (`~`), expand the tilde to the value
-of the `user.home` system property. If the `f` begins with a
-tilde immediately followed by some characters, they are assumed to
-be a username. This is expanded to the path to that user's home
-directory. This is (naively) assumed to be a directory with the same
-name as the user relative to the parent of the current value of
-`user.home`. Returns a `Path`
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1405-L1421">Source</a></sub></p>
+Returns `path` replacing `~` (tilde) with home dir.
+
+If `path`:
+- does not start with `~`, returns `path`.
+- starts with `~` then [`file-separator`](#babashka.fs/file-separator), `~` is replaced with `(home)`.
+e.g., `~/foo` -> `/home/myuser/foo` 
+- starts with `~` then some other chars, those other chars are
+assumed to be a username, then naively expanded to `(home username)`.
+e.g., `~someuser/foo` -> `/home/someuser/foo`  
+
+See also: [`home`](#babashka.fs/home)
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1461-L1481">Source</a></sub></p>
 
 ## <a name="babashka.fs/extension">`extension`</a>
 ``` clojure
@@ -449,37 +457,37 @@ name as the user relative to the parent of the current value of
 Function.
 
 Returns the extension of `path` via [`split-ext`](#babashka.fs/split-ext).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1056-L1059">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1104-L1107">Source</a></sub></p>
 
 ## <a name="babashka.fs/file">`file`</a>
 ``` clojure
-(file f)
-(file f & fs)
+(file path)
+(file path & paths)
 ```
 Function.
 
-Coerces arg(s) into a `File`, combining multiple paths into one.
+Returns `path`(s) coerced to a `File`, combining multiple paths into one.
 Multiple-arg versions treat the first argument as parent and subsequent args
 as children relative to the parent.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L66-L72">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L68-L74">Source</a></sub></p>
 
 ## <a name="babashka.fs/file-name">`file-name`</a>
 ``` clojure
-(file-name x)
+(file-name path)
 ```
 Function.
 
-Returns the name of the file or directory via [File#getName](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getName()).
-E.g. (file-name "foo/bar/baz") returns "baz".
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L219-L223">Source</a></sub></p>
+Returns the name of the file or directory for `path` via [File#getName](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getName()).
+E.g. `(file-name "foo/bar/baz")` returns `"baz"`.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L225-L229">Source</a></sub></p>
 
 ## <a name="babashka.fs/file-separator">`file-separator`</a>
 
 
 
 
-The system-dependent default name-separator character (as string)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L309-L311">Source</a></sub></p>
+The system-dependent default path component separator character (as string).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L316-L318">Source</a></sub></p>
 
 ## <a name="babashka.fs/file-time->instant">`file-time->instant`</a>
 ``` clojure
@@ -487,9 +495,9 @@ The system-dependent default name-separator character (as string)
 ```
 Function.
 
-Converts `ft` [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)
-to an [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L930-L934">Source</a></sub></p>
+Returns [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html) `ft`
+as [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L956-L960">Source</a></sub></p>
 
 ## <a name="babashka.fs/file-time->millis">`file-time->millis`</a>
 ``` clojure
@@ -497,9 +505,9 @@ to an [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/jav
 ```
 Function.
 
-Converts `ft` [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)
-to epoch millis (long).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L942-L946">Source</a></sub></p>
+Returns [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html) `ft`
+as epoch milliseconds (long).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L968-L972">Source</a></sub></p>
 
 ## <a name="babashka.fs/get-attribute">`get-attribute`</a>
 ``` clojure
@@ -508,33 +516,32 @@ to epoch millis (long).
 ```
 Function.
 
-Return `attribute` for `path` via [Files/getAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getAttribute(java.nio.file.Path,java.lang.String,java.nio.file.LinkOption...))
+Returns `attribute` for `path` via [Files/getAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getAttribute(java.nio.file.Path,java.lang.String,java.nio.file.LinkOption...)).
 
 Options:
 * [`:nofollow-links`](/README.md#nofollow-links)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L872-L882">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L895-L905">Source</a></sub></p>
 
 ## <a name="babashka.fs/glob">`glob`</a>
 ``` clojure
-(glob root pattern)
-(glob root pattern opts)
+(glob root-dir pattern)
+(glob root-dir pattern opts)
 ```
 Function.
 
-Returns a vector of paths matching glob `pattern` (on path and filename) relative to `root` dir.
+Returns a vector of paths matching glob `pattern` (on path and filename) relative to `root-dir`.
 Patterns containing `**` or `/` will cause a recursive walk under
-`root`, unless overriden with `:recursive false`. Similarly, `:hidden` will be automaticaly enabled 
+`root-dir`, unless overriden with `:recursive false`. Similarly, `:hidden` will be automaticaly enabled 
 when `pattern` starts with a dot.
 Glob interpretation is done using the rules described in
 [FileSystem#getPathMatcher](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String))
 
 Options:
-
 * `:hidden` - match hidden paths. Implied `true` when `pattern` starts with a dot;
 otherwise, defaults to `false`. Note: on Windows files starting with a dot are
 not hidden, unless their hidden attribute is set.
 * [`:follow-links`](/README.md#follow-links) - follow symlinks. Defaults to `false`.
-* `:recursive` - Implied `true` when `pattern` contains `**` or `/`; otherwise, defaults to `false`.
+* `:recursive` - implied `true` when `pattern` contains `**` or `/`; otherwise, defaults to `false`.
   * `true` - `pattern` is matched against all descendant files and directories under `root`
   * `false` - `pattern` is matched only against immediate children under `root`
 * `:max-depth` - max depth to descend into directory structure, when
@@ -548,30 +555,30 @@ Examples:
 If on macOS, see [note on glob](/README.md#glob)
 
 See also: [`match`](#babashka.fs/match)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L411-L447">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L419-L454">Source</a></sub></p>
 
 ## <a name="babashka.fs/gunzip">`gunzip`</a>
 ``` clojure
 (gunzip gz-file)
-(gunzip gz-file dest)
-(gunzip gz-file dest {:keys [replace-existing]})
+(gunzip gz-file target-dir)
+(gunzip gz-file target-dir {:keys [replace-existing]})
 ```
 Function.
 
-Extracts `gz-file` to `dest` dir.
+Extracts `gz-file` to `target-dir`.
 
-If `dest` dir not specified (or `nil`) defaults to `gz-file` dir.
+If `target-dir` not specified (or `nil`) defaults to `gz-file` dir.
 
-File is extracted to `dest` dir with `gz-file` [`file-name`](#babashka.fs/file-name) without `.gz` extension.
+File is extracted to `target-dir` with `gz-file` [`file-name`](#babashka.fs/file-name) without `.gz` extension.
 
-Creates `dest` dir(s) if necessary.
+Creates `target-dir` dir(s) if necessary.
 The `gz-file` is not deleted.
 
 Options:
 * `:replace-existing` - when `true` overwrites existing file
 
 See also: [`gzip`](#babashka.fs/gzip)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1296-L1325">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1348-L1377">Source</a></sub></p>
 
 ## <a name="babashka.fs/gzip">`gzip`</a>
 ``` clojure
@@ -580,31 +587,31 @@ See also: [`gzip`](#babashka.fs/gzip)
 ```
 Function.
 
-Gzips `source-file` to `dir/out-file`.
+Gzips `source-file` to `:dir`/`:out-file`.
 
 Does not store the `source-file` name in the `.gz` file.
 The `source-file` is not deleted.
 
 Options:
-* `dir`(s) created if necessary. If not specified, defaults to `source-file` dir.
-* `out-file` if not specified, defaults to `source-file` [`file-name`](#babashka.fs/file-name) with `.gz` extension.
+* `:dir`(s) - created if necessary. If not specified, defaults to `source-file` dir.
+* `:out-file` - if not specified, defaults to `source-file` [`file-name`](#babashka.fs/file-name) with `.gz` extension.
 
 Returns the created gzip file.
 
 See also: [`gunzip`](#babashka.fs/gunzip)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1327-L1357">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1379-L1409">Source</a></sub></p>
 
 ## <a name="babashka.fs/hidden?">`hidden?`</a>
 ``` clojure
-(hidden? f)
+(hidden? path)
 ```
 Function.
 
-Returns true if `f` is hidden via [Files/isHidden](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isHidden(java.nio.file.Path)).
+Returns `true` if `path` is hidden via [Files/isHidden](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isHidden(java.nio.file.Path)).
 
 TIP: some older JDKs can throw on empty-string path `(hidden "")`.
 Consider instead checking cwd via `(hidden ".")`.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L128-L133">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L130-L135">Source</a></sub></p>
 
 ## <a name="babashka.fs/home">`home`</a>
 ``` clojure
@@ -613,10 +620,12 @@ Consider instead checking cwd via `(hidden ".")`.
 ```
 Function.
 
+Returns home dir path.
+
 With no arguments, returns the current value of the `user.home`
-system property as a `Path`. If a `user` is passed, returns that user's home
+system property as a path. If a `user` is passed, returns that user's home
 directory as found in the parent of home with no args.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1397-L1403">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1451-L1459">Source</a></sub></p>
 
 ## <a name="babashka.fs/instant->file-time">`instant->file-time`</a>
 ``` clojure
@@ -624,19 +633,21 @@ directory as found in the parent of home with no args.
 ```
 Function.
 
-Converts `instant` [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html)
-to a [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L936-L940">Source</a></sub></p>
+Returns [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html) `instant`
+as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L962-L966">Source</a></sub></p>
 
 ## <a name="babashka.fs/last-modified-time">`last-modified-time`</a>
 ``` clojure
-(last-modified-time f)
-(last-modified-time f {:keys [nofollow-links], :as opts})
+(last-modified-time path)
+(last-modified-time path {:keys [nofollow-links], :as opts})
 ```
 Function.
 
-Returns last modified time of `f` as a [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L959-L964">Source</a></sub></p>
+Returns last modified time of `path` as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
+
+See also: [`set-last-modified-time`](#babashka.fs/set-last-modified-time), [`creation-time`](#babashka.fs/creation-time), [`file-time->instant`](#babashka.fs/file-time->instant), [`file-time->millis`](#babashka.fs/file-time->millis)
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L986-L993">Source</a></sub></p>
 
 ## <a name="babashka.fs/list-dir">`list-dir`</a>
 ``` clojure
@@ -645,9 +656,10 @@ Returns last modified time of `f` as a [FileTime](https://docs.oracle.com/en/jav
 ```
 Function.
 
-Returns all paths in `dir` as vector. For descending into subdirectories use [`glob`](#babashka.fs/glob).
+Returns a vector of all paths in `dir`. For descending into subdirectories use [`glob`](#babashka.fs/glob).
+
 - `glob-or-accept` - a [`glob`](#babashka.fs/glob) string such as "*.edn" or a `(fn accept [^java.nio.file.Path p]) -> truthy`
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L292-L300">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L298-L307">Source</a></sub></p>
 
 ## <a name="babashka.fs/list-dirs">`list-dirs`</a>
 ``` clojure
@@ -655,30 +667,29 @@ Returns all paths in `dir` as vector. For descending into subdirectories use [`g
 ```
 Function.
 
-Similar to list-dir but accepts multiple roots in `dirs` and returns the concatenated results.
+Similar to [`list-dir`](#babashka.fs/list-dir) but accepts multiple roots in `dirs` and returns the concatenated results.
 - `glob-or-accept` - a [`glob`](#babashka.fs/glob) string such as `"*.edn"` or a `(fn accept [^java.nio.file.Path p]) -> truthy`
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1023-L1027">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1064-L1068">Source</a></sub></p>
 
 ## <a name="babashka.fs/match">`match`</a>
 ``` clojure
-(match root pattern)
-(match root pattern {:keys [hidden follow-links max-depth recursive]})
+(match root-dir pattern)
+(match root-dir pattern {:keys [hidden follow-links max-depth recursive]})
 ```
 Function.
 
-Returns a vector of paths matching `pattern` (on path and filename) relative to `root` dir.
+Returns a vector of paths matching `pattern` (on path and filename) relative to `root-dir`.
 Pattern interpretation is done using the rules described in
 [FileSystem#getPathMatcher](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String))
 
 Options:
-
 * `:hidden` - match hidden paths - note: on Windows paths starting with
 a dot are not hidden, unless their hidden attribute is set. Defaults to
 `false`, i.e. skip hidden files and folders.
 * [`:follow-links`](/README.md#follow-links) - follow symlinks. Defaults to false.
 * `:recursive`
-  * `true`, `pattern` is matched against all descendant files and directories under `root`
-  * `false` (default), `pattern` is matched only against immediate children under `root`
+  * `true` - `pattern` is matched against all descendant files and directories under `root`
+  * `false` (default) - `pattern` is matched only against immediate children under `root`
 * `:max-depth` - max depth to descend into directory structure, when
 matching recursively. Defaults to `Integer/MAX_VALUE`.
 
@@ -686,7 +697,7 @@ Examples:
 - `(fs/match "." "regex:.*\\.clj" {:recursive true})`
 
 See also: [`glob`](#babashka.fs/glob)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L336-L409">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L345-L417">Source</a></sub></p>
 
 ## <a name="babashka.fs/millis->file-time">`millis->file-time`</a>
 ``` clojure
@@ -694,82 +705,84 @@ See also: [`glob`](#babashka.fs/glob)
 ```
 Function.
 
-Converts epoch millis (long) to a [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L948-L951">Source</a></sub></p>
+Returns epoch milliseconds (long)
+as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L974-L978">Source</a></sub></p>
 
 ## <a name="babashka.fs/modified-since">`modified-since`</a>
 ``` clojure
-(modified-since anchor file-set)
+(modified-since anchor-path path-set)
 ```
 Function.
 
-Returns seq of regular files (non-directories, non-symlinks) from `file-set` that were modified since the `anchor` path.
-The `anchor` path can be a regular file or directory, in which case
+Returns seq of regular files (non-directories, non-symlinks) from `path-set` that were modified since the `anchor-path`.
+The `anchor-path` can be a regular file or directory, in which case
 the recursive max last modified time stamp is used as the timestamp
-to compare with.  The `file-set` may be a regular file, directory or
-collection of files (e.g. returned by [`glob`](#babashka.fs/glob)). Directories are
+to compare with.  The `path-set` may be a regular file, directory or
+collection of paths (e.g. as returned by [`glob`](#babashka.fs/glob)). Directories are
 searched recursively.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1177-L1186">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1227-L1236">Source</a></sub></p>
 
 ## <a name="babashka.fs/move">`move`</a>
 ``` clojure
-(move source target)
-(move source target {:keys [:replace-existing :atomic-move]})
+(move source-path target-path)
+(move source-path target-path {:keys [:replace-existing :atomic-move]})
 ```
 Function.
 
-Move or rename dir or file `source` to `target` dir or file via [Files/move](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#move(java.nio.file.Path,java.nio.file.Path,java.nio.file.CopyOption...)).
-If `target` is a directory, moves `source` under `target`.
+Moves or renames dir or file at `source-path` to `target-path` dir or file via [Files/move](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#move(java.nio.file.Path,java.nio.file.Path,java.nio.file.CopyOption...)).
+If `target-path` is a directory, moves `source-path` under `target-path`.
 Never follows symbolic links.
 
-Returns `target` as `Path`.
+Returns `target-path` path.
 
 Options:
-* `replace-existing` - overwrite existing `target`, default `false`
-* `atomic-move` - watchers will only see complete `target` file, default `false`
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L803-L825">Source</a></sub></p>
+* `replace-existing` - overwrite existing `target-path`, default `false`
+* `atomic-move` - watchers will only see complete `target-path` file, default `false`
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L822-L844">Source</a></sub></p>
 
 ## <a name="babashka.fs/normalize">`normalize`</a>
 ``` clojure
-(normalize f)
+(normalize path)
 ```
 Function.
 
-Returns normalize `Path` for `f` via [Path#normalize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#normalize()).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L186-L189">Source</a></sub></p>
+Returns normalized path for `path` via [Path#normalize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#normalize()).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L192-L195">Source</a></sub></p>
 
 ## <a name="babashka.fs/owner">`owner`</a>
 ``` clojure
-(owner f)
-(owner f {:keys [:nofollow-links]})
+(owner path)
+(owner path {:keys [:nofollow-links]})
 ```
 Function.
 
-Returns the owner of file `f` via [Files/getOwner](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getOwner(java.nio.file.Path,java.nio.file.LinkOption...)).
+Returns the owner of `path` via [Files/getOwner](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getOwner(java.nio.file.Path,java.nio.file.LinkOption...)).
 Call `str` on return value to get the owner name as a string.
 
 Options:
 * [`:nofollow-links`](/README.md#nofollow-links)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L90-L98">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L92-L100">Source</a></sub></p>
 
 ## <a name="babashka.fs/parent">`parent`</a>
 ``` clojure
-(parent f)
+(parent path)
 ```
 Function.
 
-Returns parent of `f`. Akin to `dirname` in bash.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L827-L830">Source</a></sub></p>
+Returns parent path of `path` via [Paths/getParent](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#getParent()).
+Akin to `dirname` in bash.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L846-L850">Source</a></sub></p>
 
 ## <a name="babashka.fs/path">`path`</a>
 ``` clojure
-(path f)
+(path path)
 (path parent child)
 (path parent child & more)
 ```
 Function.
 
-Coerces arg(s) into a `Path`, combining multiple paths into one.
+Returns `path`(s) coerced to a `Path`, combining multiple paths into one.
 Multiple-arg versions treat the first argument as parent and subsequent
 args as children relative to the parent.
 <p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L51-L64">Source</a></sub></p>
@@ -780,7 +793,7 @@ args as children relative to the parent.
 
 
 The system-dependent path-separator character (as string).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L312-L314">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L320-L322">Source</a></sub></p>
 
 ## <a name="babashka.fs/posix->str">`posix->str`</a>
 ``` clojure
@@ -788,40 +801,48 @@ The system-dependent path-separator character (as string).
 ```
 Function.
 
-Converts a set of `PosixFilePermission` `p` to a string.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L480-L483">Source</a></sub></p>
+Returns permissions string, like `"rwx------"`, for a set of `PosixFilePermission` `p`.
+
+See also [`str->posix`](#babashka.fs/str->posix)
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L486-L491">Source</a></sub></p>
 
 ## <a name="babashka.fs/posix-file-permissions">`posix-file-permissions`</a>
 ``` clojure
-(posix-file-permissions f)
-(posix-file-permissions f {:keys [:nofollow-links]})
+(posix-file-permissions path)
+(posix-file-permissions path {:keys [:nofollow-links]})
 ```
 Function.
 
-Returns posix file permissions for `f`. Use [`posix->str`](#babashka.fs/posix->str) to view as a string.
+Returns a set of `PosixFilePermissions` for `path` via [Files/getPosixFilePermissions](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getPosixFilePermissions(java.nio.file.Path,java.nio.file.LinkOption...)).
+Use [`posix->str`](#babashka.fs/posix->str) to convert to a string.
 
 Options:
 * [`:nofollow-links`](/README.md#nofollow-links)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L546-L553">Source</a></sub></p>
+
+See also: [`set-posix-file-permissions`](#babashka.fs/set-posix-file-permissions)
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L559-L569">Source</a></sub></p>
 
 ## <a name="babashka.fs/read-all-bytes">`read-all-bytes`</a>
 ``` clojure
-(read-all-bytes f)
+(read-all-bytes file)
 ```
 Function.
 
-Returns contents of file `f` as byte array via [Files/readAllBytes](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllBytes(java.nio.file.Path)).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L849-L853">Source</a></sub></p>
+Returns contents of `file` as byte array via [Files/readAllBytes](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllBytes(java.nio.file.Path)).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L869-L873">Source</a></sub></p>
 
 ## <a name="babashka.fs/read-all-lines">`read-all-lines`</a>
 ``` clojure
-(read-all-lines f)
-(read-all-lines f {:keys [charset], :or {charset "utf-8"}})
+(read-all-lines file)
+(read-all-lines file {:keys [charset], :or {charset "utf-8"}})
 ```
 Function.
 
-Read all lines from a file `f` via [Files/readAllLines](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllLines(java.nio.file.Path,java.nio.charset.Charset)).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L860-L868">Source</a></sub></p>
+Return contents of `file` as a vector of lines via [Files/readAllLines](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllLines(java.nio.file.Path,java.nio.charset.Charset)).
+
+Options:
+- `:charset` - defaults to `"utf-8"`
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L880-L891">Source</a></sub></p>
 
 ## <a name="babashka.fs/read-attributes">`read-attributes`</a>
 ``` clojure
@@ -830,9 +851,12 @@ Read all lines from a file `f` via [Files/readAllLines](https://docs.oracle.com/
 ```
 Function.
 
-Same as [`read-attributes*`](#babashka.fs/read-attributes*) but turns `attributes` for `path` into a map and keywordizes keys.
-Keywordizing can be changed by passing a `:key-fn` in the `opts` map.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L910-L918">Source</a></sub></p>
+Same as [`read-attributes*`](#babashka.fs/read-attributes*) but returns requested `attributes` for `path` as a map with keywordized attribute keys.
+
+Options:
+* `:key-fn` - optionally override keywordizing function with your own.
+* [`:nofollow-links`](/README.md#nofollow-links)
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L933-L944">Source</a></sub></p>
 
 ## <a name="babashka.fs/read-attributes*">`read-attributes*`</a>
 ``` clojure
@@ -841,74 +865,78 @@ Keywordizing can be changed by passing a `:key-fn` in the `opts` map.
 ```
 Function.
 
-Reads `attributes` for `path` via [Files/readAttributes](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAttributes(java.nio.file.Path,java.lang.Class,java.nio.file.LinkOption...)).
+Returns requested `attributes` for `path` via [Files/readAttributes](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAttributes(java.nio.file.Path,java.lang.Class,java.nio.file.LinkOption...)).
 
 Options:
 * [`:nofollow-links`](/README.md#nofollow-links)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L889-L908">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L912-L931">Source</a></sub></p>
 
 ## <a name="babashka.fs/read-link">`read-link`</a>
 ``` clojure
-(read-link path)
+(read-link sym-link-path)
 ```
 Function.
 
-Reads the target of a symbolic link `path` via [Files/readSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readSymbolicLink(java.nio.file.Path)).
+Returns the immediate target of `sym-link-path` via [Files/readSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readSymbolicLink(java.nio.file.Path)).
 The target need not exist.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L743-L747">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L759-L763">Source</a></sub></p>
 
 ## <a name="babashka.fs/readable?">`readable?`</a>
 ``` clojure
-(readable? f)
+(readable? path)
 ```
 Function.
 
-Returns true if `f` is readable via [Files/isReadable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isReadable(java.nio.file.Path))
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L143-L145">Source</a></sub></p>
+Returns `true` if `path` is readable via [Files/isReadable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isReadable(java.nio.file.Path))
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L145-L147">Source</a></sub></p>
 
 ## <a name="babashka.fs/real-path">`real-path`</a>
 ``` clojure
-(real-path f)
-(real-path f {:keys [:nofollow-links]})
+(real-path path)
+(real-path path {:keys [:nofollow-links]})
 ```
 Function.
 
-Converts `f` into real `Path` via [Path#toRealPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toRealPath(java.nio.file.LinkOption...)).
+Returns real path for `path` via [Path#toRealPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toRealPath(java.nio.file.LinkOption...)).
 
 Options:
 * [`:nofollow-links`](/README.md#nofollow-links)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L81-L88">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L83-L90">Source</a></sub></p>
 
 ## <a name="babashka.fs/regular-file?">`regular-file?`</a>
 ``` clojure
-(regular-file? f)
-(regular-file? f {:keys [:nofollow-links]})
+(regular-file? path)
+(regular-file? path {:keys [:nofollow-links]})
 ```
 Function.
 
-Returns true if `f` is a regular file, using [Files/isRegularFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isRegularFile(java.nio.file.Path,java.nio.file.LinkOption...)).
+Returns `true` if `path` is a regular file via [Files/isRegularFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isRegularFile(java.nio.file.Path,java.nio.file.LinkOption...)).
 
 Options:
 * [`:nofollow-links`](/README.md#nofollow-links)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L102-L110">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L104-L112">Source</a></sub></p>
 
 ## <a name="babashka.fs/relative?">`relative?`</a>
 ``` clojure
-(relative? f)
+(relative? path)
 ```
 Function.
 
-Returns true if `f` represents a relative path (in other words, is not [`absolute?`](#babashka.fs/absolute?)).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L151-L153">Source</a></sub></p>
+Returns `true` if `path` is relative (in other words, is not [`absolute?`](#babashka.fs/absolute?)).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L153-L155">Source</a></sub></p>
 
 ## <a name="babashka.fs/relativize">`relativize`</a>
 ``` clojure
-(relativize this other)
+(relativize base-path other-path)
 ```
 Function.
 
-Returns relative `Path` by comparing `this` with `other` via [Path#relativize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#relativize(java.nio.file.Path)).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L181-L184">Source</a></sub></p>
+Returns `other-path` relative to `base-path` via [Path#relativize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#relativize(java.nio.file.Path)).
+
+Examples:
+- `(fs/relativize "a/b" "a/b/c/d")` => `c/d`
+- `(fs/relativize "a/b/c/d" "a/b")` => `../..`
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L183-L190">Source</a></sub></p>
 
 ## <a name="babashka.fs/root">`root`</a>
 ``` clojure
@@ -916,7 +944,7 @@ Returns relative `Path` by comparing `this` with `other` via [Path#relativize](h
 ```
 Function.
 
-Returns `root` for `path` as `Path`, or `nil` via [Path#getRoot](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#getRoot()).
+Returns root path for `path`, or `nil`, via [Path#getRoot](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#getRoot()).
 
 The return value depends upon the runtime platform.
 
@@ -927,16 +955,16 @@ On Windows, returns Windows specific roots, ex:
 * `//server/share` for `//server/share/foo/bar`
 
 On Linux and macOS, returns the leading `/` for anything that looks like an absolute path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L204-L217">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L210-L223">Source</a></sub></p>
 
 ## <a name="babashka.fs/same-file?">`same-file?`</a>
 ``` clojure
-(same-file? this other)
+(same-file? this-path other-path)
 ```
 Function.
 
-Returns `true` if `this` is the same file as `other` via [Files/isSamefile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isSameFile(java.nio.file.Path,java.nio.file.Path)).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L844-L847">Source</a></sub></p>
+Returns `true` if `this-path` is the same file as `other-path` via [Files/isSamefile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isSameFile(java.nio.file.Path,java.nio.file.Path)).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L864-L867">Source</a></sub></p>
 
 ## <a name="babashka.fs/set-attribute">`set-attribute`</a>
 ``` clojure
@@ -945,51 +973,64 @@ Returns `true` if `this` is the same file as `other` via [Files/isSamefile](http
 ```
 Function.
 
-Set `attribute` for `path` to `value` via [Files/setAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#setAttribute(java.nio.file.Path,java.lang.String,java.lang.Object,java.nio.file.LinkOption...))
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L920-L928">Source</a></sub></p>
+Sets `attribute` for `path` to `value` via [Files/setAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#setAttribute(java.nio.file.Path,java.lang.String,java.lang.Object,java.nio.file.LinkOption...))
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L946-L954">Source</a></sub></p>
 
 ## <a name="babashka.fs/set-creation-time">`set-creation-time`</a>
 ``` clojure
-(set-creation-time f time)
-(set-creation-time f time {:keys [nofollow-links], :as opts})
+(set-creation-time path time)
+(set-creation-time path time {:keys [nofollow-links], :as opts})
 ```
 Function.
 
-Sets creation time of `f` to time (`epoch millis` or [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)).
+Sets creation `time` of `path`.
+`time` can be `epoch milliseconds`,
+[FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html),
+or [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html) .
 
 Options:
 * [`:nofollow-links`](/README.md#nofollow-links)
 
 See [README notes](/README.md#set-creation-time) for some details on behaviour.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L982-L992">Source</a></sub></p>
+
+See also: [`creation-time`](#babashka.fs/creation-time)
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1018-L1033">Source</a></sub></p>
 
 ## <a name="babashka.fs/set-last-modified-time">`set-last-modified-time`</a>
 ``` clojure
-(set-last-modified-time f time)
-(set-last-modified-time f time {:keys [nofollow-links], :as opts})
+(set-last-modified-time path time)
+(set-last-modified-time path time {:keys [nofollow-links], :as opts})
 ```
 Function.
 
-Sets last modified time of `f` to `time` (`epoch millis` or [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L966-L971">Source</a></sub></p>
+Sets last modified `time` of `path`. 
+`time` can be `epoch milliseconds`,
+[FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html),
+or [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html).
+
+See also: [`last-modified-time`](#babashka.fs/last-modified-time)
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L995-L1005">Source</a></sub></p>
 
 ## <a name="babashka.fs/set-posix-file-permissions">`set-posix-file-permissions`</a>
 ``` clojure
-(set-posix-file-permissions f posix-file-permissions)
+(set-posix-file-permissions path posix-file-permissions)
 ```
 Function.
 
-Sets `posix-file-permissions` on `f`. Accepts a string like `"rwx------"` or a set of `PosixFilePermission`.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L541-L544">Source</a></sub></p>
+Sets `posix-file-permissions` on `path` via [Files/setPosixFilePermissions](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#setPosixFilePermissions(java.nio.file.Path,java.util.Set)).
+Accepts a string like `"rwx------"` or a set of `PosixFilePermission`.
+
+See also: [`posix-file-permissions`](#babashka.fs/posix-file-permissions)
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L551-L557">Source</a></sub></p>
 
 ## <a name="babashka.fs/size">`size`</a>
 ``` clojure
-(size f)
+(size path)
 ```
 Function.
 
-Returns the size of a file (in bytes).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L832-L835">Source</a></sub></p>
+Returns the size of `path` in bytes.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L852-L855">Source</a></sub></p>
 
 ## <a name="babashka.fs/split-ext">`split-ext`</a>
 ``` clojure
@@ -998,10 +1039,17 @@ Returns the size of a file (in bytes).
 ```
 Function.
 
-Splits `path` on extension. If provided, a specific extension `ext`, the
-extension (without dot), will be used for splitting.  Directories
-are not processed.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1029-L1047">Source</a></sub></p>
+Returns `path` split on extension.
+Leading directories in `path` are not processed.
+
+Options:
+* `:ext` - split on specified extension (do not include a leading dot) 
+  
+Examples:
+- `(fs/split-ext "foo.bar.baz")` => `["foo.bar" "baz"]`
+- `(fs/split-ext "foo.bar.baz" {:ext "bar.baz"})`  => `["foo" "bar.baz"]`
+- `(fs/split-ext "foo.bar.baz" {:ext "png"})`  => `["foo.bar.baz" nil]`
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1070-L1095">Source</a></sub></p>
 
 ## <a name="babashka.fs/split-paths">`split-paths`</a>
 ``` clojure
@@ -1009,20 +1057,21 @@ are not processed.
 ```
 Function.
 
-Splits a `joined-paths` list given as a string joined by the OS-specific [`path-separator`](#babashka.fs/path-separator) into a vec of paths.
-On UNIX systems, the separator is ':', on Microsoft Windows systems it is ';'.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1061-L1065">Source</a></sub></p>
+Returns a vector of paths from paths in `joined-paths` string.
+`joined-paths` is split on OS-specific [`path-separator`](#babashka.fs/path-separator).
+On UNIX systems, the separator is `:`, on Microsoft Windows systems it is `;`.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1109-L1114">Source</a></sub></p>
 
 ## <a name="babashka.fs/starts-with?">`starts-with?`</a>
 ``` clojure
-(starts-with? this other)
+(starts-with? this-path other-path)
 ```
 Function.
 
-Returns `true` if path `this` starts with path `other` via [Path#startsWith](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#startsWith(java.nio.file.Path)).
+Returns `true` if `this-path` starts with `other-path` via [Path#startsWith](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#startsWith(java.nio.file.Path)).
 
 See also: [`ends-with?`](#babashka.fs/ends-with?)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L565-L570">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L581-L586">Source</a></sub></p>
 
 ## <a name="babashka.fs/str->posix">`str->posix`</a>
 ``` clojure
@@ -1030,10 +1079,12 @@ See also: [`ends-with?`](#babashka.fs/ends-with?)
 ```
 Function.
 
-Converts a string `s` to a set of `PosixFilePermission`.
+Returns a set of `PosixFilePermission` for permissions string `s`.
 
 `s` is a string like `"rwx------"`.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L485-L490">Source</a></sub></p>
+
+See also [`posix->str`](#babashka.fs/posix->str)
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L493-L500">Source</a></sub></p>
 
 ## <a name="babashka.fs/strip-ext">`strip-ext`</a>
 ``` clojure
@@ -1042,17 +1093,17 @@ Converts a string `s` to a set of `PosixFilePermission`.
 ```
 Function.
 
-Strips extension for `path` via [`split-ext`](#babashka.fs/split-ext).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1049-L1054">Source</a></sub></p>
+Returns `path` with extension stripped via [`split-ext`](#babashka.fs/split-ext).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1097-L1102">Source</a></sub></p>
 
 ## <a name="babashka.fs/sym-link?">`sym-link?`</a>
 ``` clojure
-(sym-link? f)
+(sym-link? path)
 ```
 Function.
 
-Determines if `f` is a symbolic link via [Files/isSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isSymbolicLink(java.nio.file.Path)).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L765-L768">Source</a></sub></p>
+Returns `true` if `path` is a symbolic link via [Files/isSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isSymbolicLink(java.nio.file.Path)).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L781-L784">Source</a></sub></p>
 
 ## <a name="babashka.fs/temp-dir">`temp-dir`</a>
 ``` clojure
@@ -1061,7 +1112,7 @@ Determines if `f` is a symbolic link via [Files/isSymbolicLink](https://docs.ora
 Function.
 
 Returns `java.io.tmpdir` property as path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L634-L637">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L652-L655">Source</a></sub></p>
 
 ## <a name="babashka.fs/touch">`touch`</a>
 ``` clojure
@@ -1070,84 +1121,84 @@ Returns `java.io.tmpdir` property as path.
 ```
 Function.
 
-Update last modified time of `path` to `:time`, creating `path` as file if it does not exist.
+Update last modified time of `path` to `:time`, creating `path` as a file if it does not exist.
 
 If `path` is deleted by some other process/thread before `:time` is set,
 a `NoSuchFileException` will be thrown. Callers can, if their use case requires it,
 implement their own retry loop.
 
 Options:
-* `:time` last modified time (epoch milliseconds, `Instant`, or `FileTime`), defaults to current time
+* `:time` - last modified time (epoch milliseconds, `Instant`, or `FileTime`), defaults to current time
 * [`:nofollow-links`](/README.md#nofollow-links)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L994-L1021">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1035-L1062">Source</a></sub></p>
 
 ## <a name="babashka.fs/unixify">`unixify`</a>
 ``` clojure
-(unixify f)
+(unixify path)
 ```
 Function.
 
-Returns path as string with Unix-style file separators (`/`).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1520-L1526">Source</a></sub></p>
+Returns `path` as string with Unix-style file separators (`/`).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1580-L1586">Source</a></sub></p>
 
 ## <a name="babashka.fs/unzip">`unzip`</a>
 ``` clojure
 (unzip zip-file)
-(unzip zip-file dest)
-(unzip zip-file dest {:keys [replace-existing extract-fn]})
+(unzip zip-file target-dir)
+(unzip zip-file target-dir {:keys [replace-existing extract-fn]})
 ```
 Function.
 
-Unzips `zip-file` to `dest` directory (default `"."`).
+Unzips `zip-file` to `target-dir` (default `"."`).
 
-Options:
-* `:replace-existing` - `true` / `false`: overwrite existing files
-* `:extract-fn` - function that decides if the current ZipEntry
-  should be extracted. The function is only called for the file case
-  (not directories) with a map with entries:
-  * `:entry` and the current ZipEntry
-  * `:name` and the name of the ZipEntry (result of calling `getName`)
-  Extraction only occurs if a truthy value is returned (i.e. not
-  nil/false).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1192-L1230">Source</a></sub></p>
+ Options:
+ * `:replace-existing` - `true` / `false`: overwrite existing files
+ * `:extract-fn` - function that decides if the current `ZipEntry`
+   should be extracted. Extraction only occurs if a truthy value is returned (i.e. not nil/false).
+   The function is only called for for files (not directories) with a single map arg:
+   * `:entry` - the current `ZipEntry`
+   * `:name` - the name of the `ZipEntry` (result of calling `getName`)
+
+See also: [`zip`](#babashka.fs/zip).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1242-L1280">Source</a></sub></p>
 
 ## <a name="babashka.fs/update-file">`update-file`</a>
 ``` clojure
-(update-file path f & xs)
-(update-file path opts f & xs)
+(update-file file f & xs)
+(update-file file opts f & xs)
 ```
 Function.
 
-Updates the contents of text file `path` using `f` applied to old contents and `xs`.
+Updates the contents of text `file` with result of applying function `f` with old contents and args `xs`.
 Returns the new contents.
 
 Options:
 * `:charset` - charset of file, default to "utf-8"
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1501-L1518">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1561-L1578">Source</a></sub></p>
 
 ## <a name="babashka.fs/walk-file-tree">`walk-file-tree`</a>
 ``` clojure
-(walk-file-tree f {:keys [:pre-visit-dir :post-visit-dir :visit-file :visit-file-failed :follow-links :max-depth]})
+(walk-file-tree path {:keys [:pre-visit-dir :post-visit-dir :visit-file :visit-file-failed :follow-links :max-depth]})
 ```
 Function.
 
-Walks `f` using [Files/walkFileTree](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#walkFileTree(java.nio.file.Path,java.util.Set,int,java.nio.file.FileVisitor)).
+Walks `path` via [Files/walkFileTree](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#walkFileTree(java.nio.file.Path,java.util.Set,int,java.nio.file.FileVisitor)).
 
 Options:
 * [`:follow-links`](/README.md#follow-links)
-* `:max-depth` maximum directory depth to walk, defaults is unlimited
+* `:max-depth` - maximum directory depth to walk, defaults is unlimited
 * Override default visitor functions via:
-  * `:pre-visit-dir` args `[dir attrs]`
-  * `:post-visit-dir` args `[dir ex]`
-  * `:visit-file` args `[file attrs]`
-  * `:visit-file-failed` args `[file ex]`
+  * `:pre-visit-dir` - args `[dir attrs]`
+  * `:post-visit-dir` - args `[dir ex]`
+  * `:visit-file` - args `[file attrs]`
+  * `:visit-file-failed` - args `[file ex]`
 
 All visitor functions must return one of `:continue`, `:skip-subtree`, `:skip-siblings` or `:terminate`.
 A different return value will throw. When not supplied, visitor functions default
 to `(constantly :continue)`.
 
-Returns `f` as `Path`.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L227-L272">Source</a></sub></p>
+Returns `path`.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L233-L278">Source</a></sub></p>
 
 ## <a name="babashka.fs/which">`which`</a>
 ``` clojure
@@ -1156,17 +1207,18 @@ Returns `f` as `Path`.
 ```
 Function.
 
-Returns `Path` to first executable `program` found in `:paths` `opt`, similar to the `which` Unix command.
-Default for `:paths` is ([`exec-paths`](#babashka.fs/exec-paths)).
+Returns path to first executable `program` found in `:paths`, similar to the `which` Unix command.
 
-On Windows, searches for `program` with filename extensions specified in `:win-exts` option.
-Default is `["com" "exe" "bat" "cmd"]`.
+When `program` is a relative or absolute path, `:paths` option is not consulted.
+On Windows, the `:win-exts` variants are still searched.
+On other OSes, the path for `program` will be returned if executable, else `nil`.
+
+Options:
+* `:paths` - paths to search, default is return of ([`exec-paths`](#babashka.fs/exec-paths))
+* `:win-exts` - active on Windows only. Searches for `program` with filename extensions specified in `:win-exts` option.
 If `program` already includes an extension from `:win-exts`, it will be searched as-is first.
-
-When `program` is a relative or absolute path, `:paths` option is not consulted. On Windows, the `:win-exts`
-variants are still searched. On other OSes, the path for `program` will be returned if executable,
-else `nil`.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1080-L1132">Source</a></sub></p>
+Default is `["com" "exe" "bat" "cmd"]`.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1129-L1182">Source</a></sub></p>
 
 ## <a name="babashka.fs/which-all">`which-all`</a>
 ``` clojure
@@ -1175,8 +1227,8 @@ else `nil`.
 ```
 Function.
 
-Returns every `Path` to `program` found in ([`exec-paths`](#babashka.fs/exec-paths)). See [`which`](#babashka.fs/which).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1134-L1138">Source</a></sub></p>
+Returns a vector of every path to `program` found in ([`exec-paths`](#babashka.fs/exec-paths)). See [`which`](#babashka.fs/which).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1184-L1188">Source</a></sub></p>
 
 ## <a name="babashka.fs/windows?">`windows?`</a>
 ``` clojure
@@ -1184,24 +1236,26 @@ Returns every `Path` to `program` found in ([`exec-paths`](#babashka.fs/exec-pat
 ```
 Function.
 
-Returns true if OS is Windows.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1423-L1426">Source</a></sub></p>
+Returns `true` if OS is Windows.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1483-L1486">Source</a></sub></p>
 
 ## <a name="babashka.fs/with-temp-dir">`with-temp-dir`</a>
 ``` clojure
-(with-temp-dir [binding-name] & body)
-(with-temp-dir [binding-name options] & body)
+(with-temp-dir [temp-dir] & body)
+(with-temp-dir [temp-dir opts] & body)
 ```
 Macro.
 
-Evaluates body with binding-name bound to the result of `(create-temp-dir
-options)`. See [`create-temp-dir`](#babashka.fs/create-temp-dir) for valid `options`.
+Evaluates body with `temp-dir` bound to the result of `(create-temp-dir
+opts)`.
 
-The directory will be removed with [`delete-tree`](#babashka.fs/delete-tree) on exit from the scope,
-unless the option `:keep true` is used.
+By default, the `temp-dir` will be removed with [`delete-tree`](#babashka.fs/delete-tree) on exit from the scope.
 
+Options:
+* see [`delete-tree`](#babashka.fs/delete-tree)
+* `:keep` - if `true` does not delete the directory on exit from macro scope. 
+  
 Example:
-
 ```
 (with-temp-dir [d]
   (let [t (path d "extract")
@@ -1211,31 +1265,31 @@ Example:
 ;; d no longer exists here
 ```
   
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1361-L1389">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1413-L1443">Source</a></sub></p>
 
 ## <a name="babashka.fs/writable?">`writable?`</a>
 ``` clojure
-(writable? f)
+(writable? path)
 ```
 Function.
 
-Returns true if `f` is writable via [Files/isWritable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isWritable(java.nio.file.Path))
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L147-L149">Source</a></sub></p>
+Returns `true` if `path` is writable via [Files/isWritable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isWritable(java.nio.file.Path))
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L149-L151">Source</a></sub></p>
 
 ## <a name="babashka.fs/write-bytes">`write-bytes`</a>
 ``` clojure
-(write-bytes path bytes)
-(write-bytes path bytes {:keys [append create truncate-existing write], :as opts})
+(write-bytes file bytes)
+(write-bytes file bytes {:keys [append create truncate-existing write], :as opts})
 ```
 Function.
 
-Writes `bytes` to `path` via [Files/write](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#write(java.nio.file.Path,byte%5B%5D,java.nio.file.OpenOption...)).
+Writes `bytes` to `file` via [Files/write](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#write(java.nio.file.Path,byte%5B%5D,java.nio.file.OpenOption...)).
 
 Options:
-* `:create` (default `true`)
-* `:truncate-existing` (default `true`)
-* `:write` (default `true`)
-* `:append` (default `false`)
+* `:create` - (default `true`)
+* `:truncate-existing` - (default `true`)
+* `:write` - (default `true`)
+* `:append` - (default `false`)
 * or any `java.nio.file.StandardOption`.
 
 Examples:
@@ -1244,19 +1298,19 @@ Examples:
 (fs/write-bytes f (.getBytes (String. "foo"))) ;; overwrites + truncates or creates new file
 (fs/write-bytes f (.getBytes (String. "foo")) {:append true})
 ```
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1454-L1478">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1514-L1538">Source</a></sub></p>
 
 ## <a name="babashka.fs/write-lines">`write-lines`</a>
 ``` clojure
-(write-lines path lines)
-(write-lines path lines {:keys [charset], :or {charset "utf-8"}, :as opts})
+(write-lines file lines)
+(write-lines file lines {:keys [charset], :or {charset "utf-8"}, :as opts})
 ```
 Function.
 
-Writes `lines`, a seqable of strings to `path` via [Files/write](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#write(java.nio.file.Path,java.lang.Iterable,java.nio.charset.Charset,java.nio.file.OpenOption...)).
+Writes `lines`, a seqable of strings, to `file` via [Files/write](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#write(java.nio.file.Path,java.lang.Iterable,java.nio.charset.Charset,java.nio.file.OpenOption...)).
 
 Options:
-* `:charset` (default `"utf-8"`)
+* `:charset` - (default `"utf-8"`)
 
 Open options:
 * `:create` (default `true`)
@@ -1264,7 +1318,7 @@ Open options:
 * `:write` (default `true`)
 * `:append` (default `false`)
 * or any `java.nio.file.StandardOption`.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1480-L1499">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1540-L1559">Source</a></sub></p>
 
 ## <a name="babashka.fs/xdg-cache-home">`xdg-cache-home`</a>
 ``` clojure
@@ -1273,11 +1327,11 @@ Open options:
 ```
 Function.
 
-Path representing the base directory relative to which user-specific non-essential data files should be stored as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+Returns path to user-specific non-essential data as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 
-Returns path based on the value of env-var `XDG_CACHE_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) ".cache")`.
-When provided, appends `app` to the path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1558-L1566">Source</a></sub></p>
+Uses env-var `XDG_CACHE_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) ".cache")`.
+When provided, appends `app` to the returned path.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1618-L1626">Source</a></sub></p>
 
 ## <a name="babashka.fs/xdg-config-home">`xdg-config-home`</a>
 ``` clojure
@@ -1286,11 +1340,11 @@ When provided, appends `app` to the path.
 ```
 Function.
 
-Path representing the base directory relative to which user-specific configuration files should be stored as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+Returns path to user-specific configuration files as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 
-Returns path based on the value of env-var `XDG_CONFIG_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) ".config")`.
-When provided, appends `app` to the path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1548-L1556">Source</a></sub></p>
+Uses env-var `XDG_CONFIG_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) ".config")`.
+When provided, appends `app` to the returned path.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1608-L1616">Source</a></sub></p>
 
 ## <a name="babashka.fs/xdg-data-home">`xdg-data-home`</a>
 ``` clojure
@@ -1299,11 +1353,11 @@ When provided, appends `app` to the path.
 ```
 Function.
 
-Path representing the base directory relative to which user-specific data files should be stored as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+Returns path to user-specific data files as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 
-Returns path based on the value of env-var `XDG_DATA_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) ".local" "share")`.
-When provided, appends `app` to the path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1568-L1576">Source</a></sub></p>
+Uses env-var `XDG_DATA_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) ".local" "share")`.
+When provided, appends `app` to the returned path.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1628-L1636">Source</a></sub></p>
 
 ## <a name="babashka.fs/xdg-state-home">`xdg-state-home`</a>
 ``` clojure
@@ -1312,25 +1366,27 @@ When provided, appends `app` to the path.
 ```
 Function.
 
-Path representing the base directory relative to which user-specific state files should be stored as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+Returns path to user-specific state files as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 
-Returns path based on the value of env-var `XDG_STATE_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) ".local" "state")`.
-When provided, appends `app` to the path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1578-L1586">Source</a></sub></p>
+Uses env-var `XDG_STATE_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) ".local" "state")`.
+When provided, appends `app` to the returned path.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1638-L1646">Source</a></sub></p>
 
 ## <a name="babashka.fs/zip">`zip`</a>
 ``` clojure
-(zip zip-file entries)
-(zip zip-file entries opts)
+(zip zip-file path-or-paths)
+(zip zip-file path-or-paths opts)
 ```
 Function.
 
-Zips entry or `entries` into `zip-file`. An entry may be a file or
+Zips `path-or-paths` into `zip-file`. A path may be a file or
 directory. Directories are included recursively and their names are
-preserved in the zip file. Currently only accepts relative entries.
+preserved in the zip file. Currently only accepts relative paths.
 
 Options:
-* `:root`: directory which will be elided in zip. E.g.: `(fs/zip ["src"] {:root "src"})`
-* `:path-fn`: a single-arg function from file system path to zip entry path.
-  
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1263-L1290">Source</a></sub></p>
+* `:root` - optional directory to be elided in `zip-file` entries. E.g.: `(fs/zip ["src"] {:root "src"})`
+* `:path-fn` - an optional custom path conversion function.
+A single-arg function called for each file sytem path returning the path to be used for the corresponding zip entry.
+
+See also: [`unzip`](#babashka.fs/unzip).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1313-L1342">Source</a></sub></p>

--- a/API.md
+++ b/API.md
@@ -1,16 +1,16 @@
 # Table of contents
 -  [`babashka.fs`](#babashka.fs) 
     -  [`absolute?`](#babashka.fs/absolute?) - Returns <code>true</code> if <code>path</code> is absolute via [Path#isAbsolute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#isAbsolute()).
-    -  [`absolutize`](#babashka.fs/absolutize) - Returns absolute path for <code>path</code> via [Path#toAbsolutePath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toAbsolutePath()).
-    -  [`canonicalize`](#babashka.fs/canonicalize) - Returns canonical path for <code>path</code> via [File#getCanonicalPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getCanonicalPath()).
+    -  [`absolutize`](#babashka.fs/absolutize) - Converts <code>path</code> into an absolute <code>Path</code> via [Path#toAbsolutePath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toAbsolutePath()).
+    -  [`canonicalize`](#babashka.fs/canonicalize) - Returns the canonical <code>Path</code> for <code>path</code> via [File#getCanonicalPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getCanonicalPath()).
     -  [`components`](#babashka.fs/components) - Returns a seq of paths for all components of <code>path</code>.
     -  [`copy`](#babashka.fs/copy) - Copies <code>source-file</code> to <code>target-path</code> dir or file via [Files/copy](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#copy(java.nio.file.Path,java.nio.file.Path,java.nio.file.CopyOption...)).
     -  [`copy-tree`](#babashka.fs/copy-tree) - Copies entire file tree from <code>source-dir</code> to <code>target-dir</code>.
-    -  [`create-dir`](#babashka.fs/create-dir) - Returns new <code>dir</code> created via [Files/createDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectory(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
-    -  [`create-dirs`](#babashka.fs/create-dirs) - Returns <code>dir</code> after creating directories for <code>dir</code> via [Files/createDirectories](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectories(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
-    -  [`create-file`](#babashka.fs/create-file) - Returns new empty <code>file</code> created via [Files/createFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createFile(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
-    -  [`create-link`](#babashka.fs/create-link) - Returns a new hard <code>link</code> (directory entry) for an <code>existing-file</code> created via [Files/createLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createLink(java.nio.file.Path,java.nio.file.Path)).
-    -  [`create-sym-link`](#babashka.fs/create-sym-link) - Returns new symbolic <code>link</code> to <code>target-path</code> created via [Files/createSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createSymbolicLink(java.nio.file.Path,java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+    -  [`create-dir`](#babashka.fs/create-dir) - Creates <code>dir</code> via [Files/createDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectory(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+    -  [`create-dirs`](#babashka.fs/create-dirs) - Creates <code>dir</code> via [Files/createDirectories](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectories(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+    -  [`create-file`](#babashka.fs/create-file) - Creates empty <code>file</code> via [Files/createFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createFile(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+    -  [`create-link`](#babashka.fs/create-link) - Creates a new hard <code>link</code> (directory entry) for an <code>existing-file</code> via [Files/createLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createLink(java.nio.file.Path,java.nio.file.Path)).
+    -  [`create-sym-link`](#babashka.fs/create-sym-link) - Creates a symbolic <code>link</code> to <code>target-path</code> via [Files/createSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createSymbolicLink(java.nio.file.Path,java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
     -  [`create-temp-dir`](#babashka.fs/create-temp-dir) - Returns path to directory created via [Files/createTempDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createTempDirectory(java.nio.file.Path,java.lang.String,java.nio.file.attribute.FileAttribute...)).
     -  [`create-temp-file`](#babashka.fs/create-temp-file) - Returns path to empty file created via [Files/createTempFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createTempFile(java.nio.file.Path,java.lang.String,java.lang.String,java.nio.file.attribute.FileAttribute...)).
     -  [`creation-time`](#babashka.fs/creation-time) - Returns creation time of <code>path</code> as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
@@ -26,39 +26,39 @@
     -  [`exists?`](#babashka.fs/exists?) - Returns <code>true</code> if <code>path</code> exists via [Files/exists](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#exists(java.nio.file.Path,java.nio.file.LinkOption...)).
     -  [`expand-home`](#babashka.fs/expand-home) - Returns <code>path</code> replacing <code>~</code> (tilde) with home dir.
     -  [`extension`](#babashka.fs/extension) - Returns the extension of <code>path</code> via [<code>split-ext</code>](#babashka.fs/split-ext).
-    -  [`file`](#babashka.fs/file) - Returns <code>path</code>(s) coerced to a <code>File</code>, combining multiple paths into one.
+    -  [`file`](#babashka.fs/file) - Coerces <code>path</code>(s) into a <code>File</code>, combining multiple paths into one.
     -  [`file-name`](#babashka.fs/file-name) - Returns the name of the file or directory for <code>path</code> via [File#getName](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getName()).
     -  [`file-separator`](#babashka.fs/file-separator) - The system-dependent default path component separator character (as string).
-    -  [`file-time->instant`](#babashka.fs/file-time->instant) - Returns [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html) <code>ft</code> as [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html).
-    -  [`file-time->millis`](#babashka.fs/file-time->millis) - Returns [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html) <code>ft</code> as epoch milliseconds (long).
-    -  [`get-attribute`](#babashka.fs/get-attribute) - Returns <code>attribute</code> for <code>path</code> via [Files/getAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getAttribute(java.nio.file.Path,java.lang.String,java.nio.file.LinkOption...)).
+    -  [`file-time->instant`](#babashka.fs/file-time->instant) - Converts <code>ft</code> [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html) to an [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html).
+    -  [`file-time->millis`](#babashka.fs/file-time->millis) - Converts <code>ft</code> [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html) to epoch milliseconds (long).
+    -  [`get-attribute`](#babashka.fs/get-attribute) - Returns value of <code>attribute</code> for <code>path</code> via [Files/getAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getAttribute(java.nio.file.Path,java.lang.String,java.nio.file.LinkOption...)).
     -  [`glob`](#babashka.fs/glob) - Returns a vector of paths matching glob <code>pattern</code> (on path and filename) relative to <code>root-dir</code>.
     -  [`gunzip`](#babashka.fs/gunzip) - Extracts <code>gz-file</code> to <code>target-dir</code>.
     -  [`gzip`](#babashka.fs/gzip) - Gzips <code>source-file</code> to <code>:dir</code>/<code>:out-file</code>.
     -  [`hidden?`](#babashka.fs/hidden?) - Returns <code>true</code> if <code>path</code> is hidden via [Files/isHidden](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isHidden(java.nio.file.Path)).
     -  [`home`](#babashka.fs/home) - Returns home dir path.
-    -  [`instant->file-time`](#babashka.fs/instant->file-time) - Returns [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html) <code>instant</code> as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
+    -  [`instant->file-time`](#babashka.fs/instant->file-time) - Converts <code>instant</code> [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html) to a [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
     -  [`last-modified-time`](#babashka.fs/last-modified-time) - Returns last modified time of <code>path</code> as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
     -  [`list-dir`](#babashka.fs/list-dir) - Returns a vector of all paths in <code>dir</code>.
     -  [`list-dirs`](#babashka.fs/list-dirs) - Similar to [<code>list-dir</code>](#babashka.fs/list-dir) but accepts multiple roots in <code>dirs</code> and returns the concatenated results.
     -  [`match`](#babashka.fs/match) - Returns a vector of paths matching <code>pattern</code> (on path and filename) relative to <code>root-dir</code>.
-    -  [`millis->file-time`](#babashka.fs/millis->file-time) - Returns epoch milliseconds (long) as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
+    -  [`millis->file-time`](#babashka.fs/millis->file-time) - Converts epoch milliseconds (long) to a [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
     -  [`modified-since`](#babashka.fs/modified-since) - Returns seq of regular files (non-directories, non-symlinks) from <code>path-set</code> that were modified since the <code>anchor-path</code>.
     -  [`move`](#babashka.fs/move) - Moves or renames dir or file at <code>source-path</code> to <code>target-path</code> dir or file via [Files/move](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#move(java.nio.file.Path,java.nio.file.Path,java.nio.file.CopyOption...)).
-    -  [`normalize`](#babashka.fs/normalize) - Returns normalized path for <code>path</code> via [Path#normalize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#normalize()).
+    -  [`normalize`](#babashka.fs/normalize) - Returns normalized <code>Path</code> for <code>path</code> via [Path#normalize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#normalize()).
     -  [`owner`](#babashka.fs/owner) - Returns the owner of <code>path</code> via [Files/getOwner](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getOwner(java.nio.file.Path,java.nio.file.LinkOption...)).
-    -  [`parent`](#babashka.fs/parent) - Returns parent path of <code>path</code> via [Paths/getParent](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#getParent()).
-    -  [`path`](#babashka.fs/path) - Returns <code>path</code>(s) coerced to a <code>Path</code>, combining multiple paths into one.
+    -  [`parent`](#babashka.fs/parent) - Returns parent path of <code>path</code> via [Path#getParent](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#getParent()).
+    -  [`path`](#babashka.fs/path) - Coerces <code>path</code>(s) into a <code>Path</code>, combining multiple paths into one.
     -  [`path-separator`](#babashka.fs/path-separator) - The system-dependent path-separator character (as string).
-    -  [`posix->str`](#babashka.fs/posix->str) - Returns permissions string, like <code>&quot;rwx------&quot;</code>, for a set of <code>PosixFilePermission</code> <code>p</code>.
-    -  [`posix-file-permissions`](#babashka.fs/posix-file-permissions) - Returns a set of <code>PosixFilePermissions</code> for <code>path</code> via [Files/getPosixFilePermissions](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getPosixFilePermissions(java.nio.file.Path,java.nio.file.LinkOption...)).
+    -  [`posix->str`](#babashka.fs/posix->str) - Converts a set of <code>PosixFilePermission</code> <code>p</code> to a string, like <code>&quot;rwx------&quot;</code>.
+    -  [`posix-file-permissions`](#babashka.fs/posix-file-permissions) - Returns a set of <code>PosixFilePermission</code> for <code>path</code> via [Files/getPosixFilePermissions](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getPosixFilePermissions(java.nio.file.Path,java.nio.file.LinkOption...)).
     -  [`read-all-bytes`](#babashka.fs/read-all-bytes) - Returns contents of <code>file</code> as byte array via [Files/readAllBytes](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllBytes(java.nio.file.Path)).
-    -  [`read-all-lines`](#babashka.fs/read-all-lines) - Return contents of <code>file</code> as a vector of lines via [Files/readAllLines](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllLines(java.nio.file.Path,java.nio.charset.Charset)).
+    -  [`read-all-lines`](#babashka.fs/read-all-lines) - Returns contents of <code>file</code> as a vector of lines via [Files/readAllLines](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllLines(java.nio.file.Path,java.nio.charset.Charset)).
     -  [`read-attributes`](#babashka.fs/read-attributes) - Same as [<code>read-attributes*</code>](#babashka.fs/read-attributes*) but returns requested <code>attributes</code> for <code>path</code> as a map with keywordized attribute keys.
     -  [`read-attributes*`](#babashka.fs/read-attributes*) - Returns requested <code>attributes</code> for <code>path</code> via [Files/readAttributes](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAttributes(java.nio.file.Path,java.lang.Class,java.nio.file.LinkOption...)).
     -  [`read-link`](#babashka.fs/read-link) - Returns the immediate target of <code>sym-link-path</code> via [Files/readSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readSymbolicLink(java.nio.file.Path)).
     -  [`readable?`](#babashka.fs/readable?) - Returns <code>true</code> if <code>path</code> is readable via [Files/isReadable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isReadable(java.nio.file.Path)).
-    -  [`real-path`](#babashka.fs/real-path) - Returns real path for <code>path</code> via [Path#toRealPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toRealPath(java.nio.file.LinkOption...)).
+    -  [`real-path`](#babashka.fs/real-path) - Converts <code>path</code> into real <code>Path</code> via [Path#toRealPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toRealPath(java.nio.file.LinkOption...)).
     -  [`regular-file?`](#babashka.fs/regular-file?) - Returns <code>true</code> if <code>path</code> is a regular file via [Files/isRegularFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isRegularFile(java.nio.file.Path,java.nio.file.LinkOption...)).
     -  [`relative?`](#babashka.fs/relative?) - Returns <code>true</code> if <code>path</code> is relative (in other words, is not [<code>absolute?</code>](#babashka.fs/absolute?)).
     -  [`relativize`](#babashka.fs/relativize) - Returns <code>other-path</code> relative to <code>base-path</code> via [Path#relativize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#relativize(java.nio.file.Path)).
@@ -69,14 +69,14 @@
     -  [`set-last-modified-time`](#babashka.fs/set-last-modified-time) - Sets last modified <code>time</code> of <code>path</code>.
     -  [`set-posix-file-permissions`](#babashka.fs/set-posix-file-permissions) - Sets <code>posix-file-permissions</code> on <code>path</code> via [Files/setPosixFilePermissions](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#setPosixFilePermissions(java.nio.file.Path,java.util.Set)).
     -  [`size`](#babashka.fs/size) - Returns the size of <code>path</code> in bytes.
-    -  [`split-ext`](#babashka.fs/split-ext) - Returns <code>path</code> split on extension.
-    -  [`split-paths`](#babashka.fs/split-paths) - Returns a vector of paths from paths in <code>joined-paths</code> string.
+    -  [`split-ext`](#babashka.fs/split-ext) - Splits <code>path</code> on extension.
+    -  [`split-paths`](#babashka.fs/split-paths) - Splits <code>joined-paths</code> string into a vector of paths by OS-specific [<code>path-separator</code>](#babashka.fs/path-separator).
     -  [`starts-with?`](#babashka.fs/starts-with?) - Returns <code>true</code> if <code>this-path</code> starts with <code>other-path</code> via [Path#startsWith](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#startsWith(java.nio.file.Path)).
-    -  [`str->posix`](#babashka.fs/str->posix) - Returns a set of <code>PosixFilePermission</code> for permissions string <code>s</code>.
-    -  [`strip-ext`](#babashka.fs/strip-ext) - Returns <code>path</code> with extension stripped via [<code>split-ext</code>](#babashka.fs/split-ext).
+    -  [`str->posix`](#babashka.fs/str->posix) - Converts a string <code>s</code> to a set of <code>PosixFilePermission</code>.
+    -  [`strip-ext`](#babashka.fs/strip-ext) - Strips extension from <code>path</code> via [<code>split-ext</code>](#babashka.fs/split-ext).
     -  [`sym-link?`](#babashka.fs/sym-link?) - Returns <code>true</code> if <code>path</code> is a symbolic link via [Files/isSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isSymbolicLink(java.nio.file.Path)).
     -  [`temp-dir`](#babashka.fs/temp-dir) - Returns <code>java.io.tmpdir</code> property as path.
-    -  [`touch`](#babashka.fs/touch) - Update last modified time of <code>path</code> to <code>:time</code>, creating <code>path</code> as a file if it does not exist.
+    -  [`touch`](#babashka.fs/touch) - Updates last modified time of <code>path</code> to <code>:time</code>, creating <code>path</code> as a file if it does not exist.
     -  [`unixify`](#babashka.fs/unixify) - Returns <code>path</code> as string with Unix-style file separators (<code>/</code>).
     -  [`unzip`](#babashka.fs/unzip) - Unzips <code>zip-file</code> to <code>target-dir</code> (default <code>&quot;.&quot;</code>).
     -  [`update-file`](#babashka.fs/update-file) - Updates the contents of text <code>file</code> with result of applying function <code>f</code> with old contents and args <code>xs</code>.
@@ -117,7 +117,7 @@ Returns `true` if `path` is absolute via [Path#isAbsolute](https://docs.oracle.c
 ```
 Function.
 
-Returns absolute path for `path` via [Path#toAbsolutePath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toAbsolutePath()).
+Converts `path` into an absolute `Path` via [Path#toAbsolutePath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toAbsolutePath()).
 <p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L179-L181">Source</a></sub></p>
 
 ## <a name="babashka.fs/canonicalize">`canonicalize`</a>
@@ -127,7 +127,7 @@ Returns absolute path for `path` via [Path#toAbsolutePath](https://docs.oracle.c
 ```
 Function.
 
-Returns canonical path for `path` via [File#getCanonicalPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getCanonicalPath()).
+Returns the canonical `Path` for `path` via [File#getCanonicalPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getCanonicalPath()).
 
 Options:
 * [`:nofollow-links`](/README.md#nofollow-links) - when set, falls back on [`absolutize`](#babashka.fs/absolutize) + [`normalize`](#babashka.fs/normalize).
@@ -158,7 +158,9 @@ Options:
 * `:replace-existing`
 * `:copy-attributes`
 * [`:nofollow-links`](/README.md#nofollow-links) - used to determine to copy symbolic link itself or not.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L465-L484">Source</a></sub></p>
+
+Returns `target-path`.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L465-L486">Source</a></sub></p>
 
 ## <a name="babashka.fs/copy-tree">`copy-tree`</a>
 ``` clojure
@@ -168,11 +170,11 @@ Options:
 Function.
 
 Copies entire file tree from `source-dir` to `target-dir`. Creates `target-dir` if needed.
- 
+
 Options:
 * same as [`copy`](#babashka.fs/copy)
 * `:posix-file-permissions` - string format unix-like system permissions passed to [`create-dirs`](#babashka.fs/create-dirs) when creating `target-dir`.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L595-L650">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L601-L656">Source</a></sub></p>
 
 ## <a name="babashka.fs/create-dir">`create-dir`</a>
 ``` clojure
@@ -181,13 +183,15 @@ Options:
 ```
 Function.
 
-Returns new `dir` created via [Files/createDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectory(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+Creates `dir` via [Files/createDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectory(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
 Does not create parents.
+
+Returns `dir`.
 
 Options:
 * `:posix-file-permissions` - string format for unix-like system permissions for `dir`, as described in [`str->posix`](#babashka.fs/str->posix).
 Affected by [umask](/README.md#umask).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L523-L534">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L525-L538">Source</a></sub></p>
 
 ## <a name="babashka.fs/create-dirs">`create-dirs`</a>
 ``` clojure
@@ -196,14 +200,16 @@ Affected by [umask](/README.md#umask).
 ```
 Function.
 
-Returns `dir` after creating directories for `dir` via [Files/createDirectories](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectories(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+Creates `dir` via [Files/createDirectories](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectories(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
 Also creates parents if needed.
 Does not throw an exception if the dirs exist already. Similar to `mkdir -p` shell command.
-  
+
+Returns `dir`.
+
 Options:
 * `:posix-file-permissions` - string format for unix-like system permissions for `dir`, as described in [`str->posix`](#babashka.fs/str->posix).
 Affected by [umask](/README.md#umask).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L536-L549">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L540-L555">Source</a></sub></p>
 
 ## <a name="babashka.fs/create-file">`create-file`</a>
 ``` clojure
@@ -212,12 +218,14 @@ Affected by [umask](/README.md#umask).
 ```
 Function.
 
-Returns new empty `file` created via [Files/createFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createFile(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+Creates empty `file` via [Files/createFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createFile(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+
+Returns `file`.
 
 Options:
 * `:posix-file-permissions` - string format for unix-like system permissions for `file`, as described in [`str->posix`](#babashka.fs/str->posix).
 Affected by [umask](/README.md#umask).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L810-L820">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L820-L832">Source</a></sub></p>
 
 ## <a name="babashka.fs/create-link">`create-link`</a>
 ``` clojure
@@ -225,8 +233,10 @@ Affected by [umask](/README.md#umask).
 ```
 Function.
 
-Returns a new hard `link` (directory entry) for an `existing-file` created via [Files/createLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createLink(java.nio.file.Path,java.nio.file.Path)).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L752-L757">Source</a></sub></p>
+Creates a new hard `link` (directory entry) for an `existing-file` via [Files/createLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createLink(java.nio.file.Path,java.nio.file.Path)).
+
+Returns `link`.
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L760-L767">Source</a></sub></p>
 
 ## <a name="babashka.fs/create-sym-link">`create-sym-link`</a>
 ``` clojure
@@ -234,11 +244,13 @@ Returns a new hard `link` (directory entry) for an `existing-file` created via [
 ```
 Function.
 
-Returns new symbolic `link` to `target-path` created via [Files/createSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createSymbolicLink(java.nio.file.Path,java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+Creates a symbolic `link` to `target-path` via [Files/createSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createSymbolicLink(java.nio.file.Path,java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+
+Returns `link`.
 
 As of this writing, JDKs do not recognize empty-string `target-path` `""` as the cwd.
 Consider instead using a `target-path` of `"."` to link to the cwd.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L741-L750">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L747-L758">Source</a></sub></p>
 
 ## <a name="babashka.fs/create-temp-dir">`create-temp-dir`</a>
 ``` clojure
@@ -270,7 +282,7 @@ Examples:
 * `(create-temp-dir {:posix-file-permissions "rwx------"})`
 * `(create-temp-dir {:dir (path (cwd) "_workdir") :prefix "process-1-"})`
   
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L657-L693">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L663-L699">Source</a></sub></p>
 
 ## <a name="babashka.fs/create-temp-file">`create-temp-file`</a>
 ``` clojure
@@ -305,7 +317,7 @@ Examples:
 * `(create-temp-file {:posix-file-permissions "rw-------"})`
 * `(create-temp-file {:dir (path (cwd) "_workdir") :prefix "process-1-" :suffix "-queue"})`
   
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L695-L739">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L701-L745">Source</a></sub></p>
 
 ## <a name="babashka.fs/creation-time">`creation-time`</a>
 ``` clojure
@@ -319,7 +331,7 @@ Returns creation time of `path` as [FileTime](https://docs.oracle.com/en/java/ja
 See [README notes](/README.md#creation-time) for some details on behaviour.
 
 See also: [`set-creation-time`](#babashka.fs/set-creation-time), [`last-modified-time`](#babashka.fs/last-modified-time), [`file-time->instant`](#babashka.fs/file-time->instant), [`file-time->millis`](#babashka.fs/file-time->millis)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1007-L1016">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1018-L1027">Source</a></sub></p>
 
 ## <a name="babashka.fs/cwd">`cwd`</a>
 ``` clojure
@@ -328,7 +340,7 @@ See also: [`set-creation-time`](#babashka.fs/set-creation-time), [`last-modified
 Function.
 
 Returns current working directory path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1488-L1491">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1497-L1500">Source</a></sub></p>
 
 ## <a name="babashka.fs/delete">`delete`</a>
 ``` clojure
@@ -339,7 +351,7 @@ Function.
 Deletes `path` via [Files/delete](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#delete(java.nio.file.Path)).
 Returns `nil` if the delete was successful,
 throws otherwise. Does not follow symlinks.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L765-L772">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L775-L782">Source</a></sub></p>
 
 ## <a name="babashka.fs/delete-if-exists">`delete-if-exists`</a>
 ``` clojure
@@ -350,7 +362,7 @@ Function.
 Deletes `path` if it exists via [Files/deleteIfExists](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#deleteIfExists(java.nio.file.Path)).
 Returns `true` if the delete was successful,
 `false` if `path` didn't exist. Does not follow symlinks.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L774-L779">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L784-L789">Source</a></sub></p>
 
 ## <a name="babashka.fs/delete-on-exit">`delete-on-exit`</a>
 ``` clojure
@@ -360,7 +372,7 @@ Function.
 
 Requests delete of `path` on exit via [File#deleteOnExit](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#deleteOnExit()).
 Returns `path`.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L857-L862">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L869-L874">Source</a></sub></p>
 
 ## <a name="babashka.fs/delete-tree">`delete-tree`</a>
 ``` clojure
@@ -373,7 +385,7 @@ Deletes the file tree at `root-path` using [`walk-file-tree`](#babashka.fs/walk-
 
 Options:
 * `:force` - if `true` forces deletion of read-only files/directories. Similar to `chmod -R +wx` + `rm -rf` shell commands.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L786-L808">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L796-L818">Source</a></sub></p>
 
 ## <a name="babashka.fs/directory?">`directory?`</a>
 ``` clojure
@@ -397,7 +409,7 @@ Function.
 Returns `true` if `this-path` ends with `other-path` via [Path#endsWith](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#endsWith(java.nio.file.Path)).
 
 See also: [`starts-with?`](#babashka.fs/starts-with?)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L588-L593">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L594-L599">Source</a></sub></p>
 
 ## <a name="babashka.fs/exec-paths">`exec-paths`</a>
 ``` clojure
@@ -407,7 +419,7 @@ Function.
 
 Returns a vector of command search paths (from the `PATH` environment variable). Same
 as `(split-paths (System/getenv "PATH"))`.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1116-L1120">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1126-L1130">Source</a></sub></p>
 
 ## <a name="babashka.fs/executable?">`executable?`</a>
 ``` clojure
@@ -442,13 +454,13 @@ Returns `path` replacing `~` (tilde) with home dir.
 If `path`:
 - does not start with `~`, returns `path`.
 - starts with `~` then [`file-separator`](#babashka.fs/file-separator), `~` is replaced with `(home)`.
-e.g., `~/foo` -> `/home/myuser/foo` 
+e.g., `~/foo` -> `/home/myuser/foo`
 - starts with `~` then some other chars, those other chars are
 assumed to be a username, then naively expanded to `(home username)`.
-e.g., `~someuser/foo` -> `/home/someuser/foo`  
+e.g., `~someuser/foo` -> `/home/someuser/foo`
 
 See also: [`home`](#babashka.fs/home)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1461-L1481">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1470-L1490">Source</a></sub></p>
 
 ## <a name="babashka.fs/extension">`extension`</a>
 ``` clojure
@@ -457,7 +469,7 @@ See also: [`home`](#babashka.fs/home)
 Function.
 
 Returns the extension of `path` via [`split-ext`](#babashka.fs/split-ext).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1104-L1107">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1115-L1118">Source</a></sub></p>
 
 ## <a name="babashka.fs/file">`file`</a>
 ``` clojure
@@ -466,7 +478,7 @@ Returns the extension of `path` via [`split-ext`](#babashka.fs/split-ext).
 ```
 Function.
 
-Returns `path`(s) coerced to a `File`, combining multiple paths into one.
+Coerces `path`(s) into a `File`, combining multiple paths into one.
 Multiple-arg versions treat the first argument as parent and subsequent args
 as children relative to the parent.
 <p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L68-L74">Source</a></sub></p>
@@ -495,9 +507,9 @@ The system-dependent default path component separator character (as string).
 ```
 Function.
 
-Returns [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html) `ft`
-as [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L956-L960">Source</a></sub></p>
+Converts `ft` [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)
+to an [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L968-L972">Source</a></sub></p>
 
 ## <a name="babashka.fs/file-time->millis">`file-time->millis`</a>
 ``` clojure
@@ -505,9 +517,9 @@ as [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/t
 ```
 Function.
 
-Returns [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html) `ft`
-as epoch milliseconds (long).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L968-L972">Source</a></sub></p>
+Converts `ft` [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)
+to epoch milliseconds (long).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L980-L984">Source</a></sub></p>
 
 ## <a name="babashka.fs/get-attribute">`get-attribute`</a>
 ``` clojure
@@ -516,11 +528,11 @@ as epoch milliseconds (long).
 ```
 Function.
 
-Returns `attribute` for `path` via [Files/getAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getAttribute(java.nio.file.Path,java.lang.String,java.nio.file.LinkOption...)).
+Returns value of `attribute` for `path` via [Files/getAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getAttribute(java.nio.file.Path,java.lang.String,java.nio.file.LinkOption...)).
 
 Options:
 * [`:nofollow-links`](/README.md#nofollow-links)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L895-L905">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L907-L917">Source</a></sub></p>
 
 ## <a name="babashka.fs/glob">`glob`</a>
 ``` clojure
@@ -531,7 +543,7 @@ Function.
 
 Returns a vector of paths matching glob `pattern` (on path and filename) relative to `root-dir`.
 Patterns containing `**` or `/` will cause a recursive walk under
-`root-dir`, unless overriden with `:recursive false`. Similarly, `:hidden` will be automaticaly enabled 
+`root-dir`, unless overriden with `:recursive false`. Similarly, `:hidden` will be automatically enabled
 when `pattern` starts with a dot.
 Glob interpretation is done using the rules described in
 [FileSystem#getPathMatcher](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String))
@@ -542,8 +554,8 @@ otherwise, defaults to `false`. Note: on Windows files starting with a dot are
 not hidden, unless their hidden attribute is set.
 * [`:follow-links`](/README.md#follow-links) - follow symlinks. Defaults to `false`.
 * `:recursive` - implied `true` when `pattern` contains `**` or `/`; otherwise, defaults to `false`.
-  * `true` - `pattern` is matched against all descendant files and directories under `root`
-  * `false` - `pattern` is matched only against immediate children under `root`
+  * `true` - `pattern` is matched against all descendant files and directories under `root-dir`
+  * `false` - `pattern` is matched only against immediate children under `root-dir`
 * `:max-depth` - max depth to descend into directory structure, when
 recursing. Defaults to `Integer/MAX_VALUE`.
 
@@ -578,7 +590,7 @@ Options:
 * `:replace-existing` - when `true` overwrites existing file
 
 See also: [`gzip`](#babashka.fs/gzip)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1348-L1377">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1358-L1387">Source</a></sub></p>
 
 ## <a name="babashka.fs/gzip">`gzip`</a>
 ``` clojure
@@ -599,7 +611,7 @@ Options:
 Returns the created gzip file.
 
 See also: [`gunzip`](#babashka.fs/gunzip)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1379-L1409">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1389-L1419">Source</a></sub></p>
 
 ## <a name="babashka.fs/hidden?">`hidden?`</a>
 ``` clojure
@@ -623,9 +635,9 @@ Function.
 Returns home dir path.
 
 With no arguments, returns the current value of the `user.home`
-system property as a path. If a `user` is passed, returns that user's home
+system property. If a `user` is passed, returns that user's home
 directory as found in the parent of home with no args.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1451-L1459">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1460-L1468">Source</a></sub></p>
 
 ## <a name="babashka.fs/instant->file-time">`instant->file-time`</a>
 ``` clojure
@@ -633,9 +645,9 @@ directory as found in the parent of home with no args.
 ```
 Function.
 
-Returns [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html) `instant`
-as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L962-L966">Source</a></sub></p>
+Converts `instant` [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html)
+to a [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L974-L978">Source</a></sub></p>
 
 ## <a name="babashka.fs/last-modified-time">`last-modified-time`</a>
 ``` clojure
@@ -647,7 +659,7 @@ Function.
 Returns last modified time of `path` as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
 
 See also: [`set-last-modified-time`](#babashka.fs/set-last-modified-time), [`creation-time`](#babashka.fs/creation-time), [`file-time->instant`](#babashka.fs/file-time->instant), [`file-time->millis`](#babashka.fs/file-time->millis)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L986-L993">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L997-L1004">Source</a></sub></p>
 
 ## <a name="babashka.fs/list-dir">`list-dir`</a>
 ``` clojure
@@ -658,7 +670,7 @@ Function.
 
 Returns a vector of all paths in `dir`. For descending into subdirectories use [`glob`](#babashka.fs/glob).
 
-- `glob-or-accept` - a [`glob`](#babashka.fs/glob) string such as "*.edn" or a `(fn accept [^java.nio.file.Path p]) -> truthy`
+- `glob-or-accept` - a [`glob`](#babashka.fs/glob) string such as `"*.edn"` or a `(fn accept [^java.nio.file.Path p]) -> truthy`
 <p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L298-L307">Source</a></sub></p>
 
 ## <a name="babashka.fs/list-dirs">`list-dirs`</a>
@@ -669,7 +681,7 @@ Function.
 
 Similar to [`list-dir`](#babashka.fs/list-dir) but accepts multiple roots in `dirs` and returns the concatenated results.
 - `glob-or-accept` - a [`glob`](#babashka.fs/glob) string such as `"*.edn"` or a `(fn accept [^java.nio.file.Path p]) -> truthy`
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1064-L1068">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1075-L1079">Source</a></sub></p>
 
 ## <a name="babashka.fs/match">`match`</a>
 ``` clojure
@@ -688,12 +700,12 @@ a dot are not hidden, unless their hidden attribute is set. Defaults to
 `false`, i.e. skip hidden files and folders.
 * [`:follow-links`](/README.md#follow-links) - follow symlinks. Defaults to false.
 * `:recursive`
-  * `true` - `pattern` is matched against all descendant files and directories under `root`
-  * `false` (default) - `pattern` is matched only against immediate children under `root`
+  * `true` - `pattern` is matched against all descendant files and directories under `root-dir`
+  * `false` (default) - `pattern` is matched only against immediate children under `root-dir`
 * `:max-depth` - max depth to descend into directory structure, when
 matching recursively. Defaults to `Integer/MAX_VALUE`.
 
-Examples: 
+Examples:
 - `(fs/match "." "regex:.*\\.clj" {:recursive true})`
 
 See also: [`glob`](#babashka.fs/glob)
@@ -705,9 +717,8 @@ See also: [`glob`](#babashka.fs/glob)
 ```
 Function.
 
-Returns epoch milliseconds (long)
-as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L974-L978">Source</a></sub></p>
+Converts epoch milliseconds (long) to a [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L986-L989">Source</a></sub></p>
 
 ## <a name="babashka.fs/modified-since">`modified-since`</a>
 ``` clojure
@@ -721,7 +732,7 @@ the recursive max last modified time stamp is used as the timestamp
 to compare with.  The `path-set` may be a regular file, directory or
 collection of paths (e.g. as returned by [`glob`](#babashka.fs/glob)). Directories are
 searched recursively.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1227-L1236">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1237-L1246">Source</a></sub></p>
 
 ## <a name="babashka.fs/move">`move`</a>
 ``` clojure
@@ -734,12 +745,12 @@ Moves or renames dir or file at `source-path` to `target-path` dir or file via [
 If `target-path` is a directory, moves `source-path` under `target-path`.
 Never follows symbolic links.
 
-Returns `target-path` path.
+Returns `target-path`.
 
 Options:
 * `replace-existing` - overwrite existing `target-path`, default `false`
 * `atomic-move` - watchers will only see complete `target-path` file, default `false`
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L822-L844">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L834-L856">Source</a></sub></p>
 
 ## <a name="babashka.fs/normalize">`normalize`</a>
 ``` clojure
@@ -747,7 +758,7 @@ Options:
 ```
 Function.
 
-Returns normalized path for `path` via [Path#normalize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#normalize()).
+Returns normalized `Path` for `path` via [Path#normalize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#normalize()).
 <p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L192-L195">Source</a></sub></p>
 
 ## <a name="babashka.fs/owner">`owner`</a>
@@ -770,9 +781,9 @@ Options:
 ```
 Function.
 
-Returns parent path of `path` via [Paths/getParent](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#getParent()).
+Returns parent path of `path` via [Path#getParent](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#getParent()).
 Akin to `dirname` in bash.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L846-L850">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L858-L862">Source</a></sub></p>
 
 ## <a name="babashka.fs/path">`path`</a>
 ``` clojure
@@ -782,7 +793,7 @@ Akin to `dirname` in bash.
 ```
 Function.
 
-Returns `path`(s) coerced to a `Path`, combining multiple paths into one.
+Coerces `path`(s) into a `Path`, combining multiple paths into one.
 Multiple-arg versions treat the first argument as parent and subsequent
 args as children relative to the parent.
 <p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L51-L64">Source</a></sub></p>
@@ -801,10 +812,10 @@ The system-dependent path-separator character (as string).
 ```
 Function.
 
-Returns permissions string, like `"rwx------"`, for a set of `PosixFilePermission` `p`.
+Converts a set of `PosixFilePermission` `p` to a string, like `"rwx------"`.
 
-See also [`str->posix`](#babashka.fs/str->posix)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L486-L491">Source</a></sub></p>
+See also: [`str->posix`](#babashka.fs/str->posix)
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L488-L493">Source</a></sub></p>
 
 ## <a name="babashka.fs/posix-file-permissions">`posix-file-permissions`</a>
 ``` clojure
@@ -813,14 +824,14 @@ See also [`str->posix`](#babashka.fs/str->posix)
 ```
 Function.
 
-Returns a set of `PosixFilePermissions` for `path` via [Files/getPosixFilePermissions](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getPosixFilePermissions(java.nio.file.Path,java.nio.file.LinkOption...)).
+Returns a set of `PosixFilePermission` for `path` via [Files/getPosixFilePermissions](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getPosixFilePermissions(java.nio.file.Path,java.nio.file.LinkOption...)).
 Use [`posix->str`](#babashka.fs/posix->str) to convert to a string.
 
 Options:
 * [`:nofollow-links`](/README.md#nofollow-links)
 
 See also: [`set-posix-file-permissions`](#babashka.fs/set-posix-file-permissions)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L559-L569">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L565-L575">Source</a></sub></p>
 
 ## <a name="babashka.fs/read-all-bytes">`read-all-bytes`</a>
 ``` clojure
@@ -829,7 +840,7 @@ See also: [`set-posix-file-permissions`](#babashka.fs/set-posix-file-permissions
 Function.
 
 Returns contents of `file` as byte array via [Files/readAllBytes](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllBytes(java.nio.file.Path)).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L869-L873">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L881-L885">Source</a></sub></p>
 
 ## <a name="babashka.fs/read-all-lines">`read-all-lines`</a>
 ``` clojure
@@ -838,11 +849,11 @@ Returns contents of `file` as byte array via [Files/readAllBytes](https://docs.o
 ```
 Function.
 
-Return contents of `file` as a vector of lines via [Files/readAllLines](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllLines(java.nio.file.Path,java.nio.charset.Charset)).
+Returns contents of `file` as a vector of lines via [Files/readAllLines](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllLines(java.nio.file.Path,java.nio.charset.Charset)).
 
 Options:
-- `:charset` - defaults to `"utf-8"`
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L880-L891">Source</a></sub></p>
+* `:charset` - defaults to `"utf-8"`
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L892-L903">Source</a></sub></p>
 
 ## <a name="babashka.fs/read-attributes">`read-attributes`</a>
 ``` clojure
@@ -856,7 +867,7 @@ Same as [`read-attributes*`](#babashka.fs/read-attributes*) but returns requeste
 Options:
 * `:key-fn` - optionally override keywordizing function with your own.
 * [`:nofollow-links`](/README.md#nofollow-links)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L933-L944">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L945-L956">Source</a></sub></p>
 
 ## <a name="babashka.fs/read-attributes*">`read-attributes*`</a>
 ``` clojure
@@ -869,7 +880,7 @@ Returns requested `attributes` for `path` via [Files/readAttributes](https://doc
 
 Options:
 * [`:nofollow-links`](/README.md#nofollow-links)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L912-L931">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L924-L943">Source</a></sub></p>
 
 ## <a name="babashka.fs/read-link">`read-link`</a>
 ``` clojure
@@ -879,7 +890,7 @@ Function.
 
 Returns the immediate target of `sym-link-path` via [Files/readSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readSymbolicLink(java.nio.file.Path)).
 The target need not exist.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L759-L763">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L769-L773">Source</a></sub></p>
 
 ## <a name="babashka.fs/readable?">`readable?`</a>
 ``` clojure
@@ -897,7 +908,7 @@ Returns `true` if `path` is readable via [Files/isReadable](https://docs.oracle.
 ```
 Function.
 
-Returns real path for `path` via [Path#toRealPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toRealPath(java.nio.file.LinkOption...)).
+Converts `path` into real `Path` via [Path#toRealPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toRealPath(java.nio.file.LinkOption...)).
 
 Options:
 * [`:nofollow-links`](/README.md#nofollow-links)
@@ -964,7 +975,7 @@ On Linux and macOS, returns the leading `/` for anything that looks like an abso
 Function.
 
 Returns `true` if `this-path` is the same file as `other-path` via [Files/isSamefile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isSameFile(java.nio.file.Path,java.nio.file.Path)).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L864-L867">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L876-L879">Source</a></sub></p>
 
 ## <a name="babashka.fs/set-attribute">`set-attribute`</a>
 ``` clojure
@@ -973,8 +984,8 @@ Returns `true` if `this-path` is the same file as `other-path` via [Files/isSame
 ```
 Function.
 
-Sets `attribute` for `path` to `value` via [Files/setAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#setAttribute(java.nio.file.Path,java.lang.String,java.lang.Object,java.nio.file.LinkOption...))
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L946-L954">Source</a></sub></p>
+Sets `attribute` for `path` to `value` via [Files/setAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#setAttribute(java.nio.file.Path,java.lang.String,java.lang.Object,java.nio.file.LinkOption...)).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L958-L966">Source</a></sub></p>
 
 ## <a name="babashka.fs/set-creation-time">`set-creation-time`</a>
 ``` clojure
@@ -986,7 +997,7 @@ Function.
 Sets creation `time` of `path`.
 `time` can be `epoch milliseconds`,
 [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html),
-or [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html) .
+or [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html).
 
 Options:
 * [`:nofollow-links`](/README.md#nofollow-links)
@@ -994,7 +1005,7 @@ Options:
 See [README notes](/README.md#set-creation-time) for some details on behaviour.
 
 See also: [`creation-time`](#babashka.fs/creation-time)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1018-L1033">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1029-L1044">Source</a></sub></p>
 
 ## <a name="babashka.fs/set-last-modified-time">`set-last-modified-time`</a>
 ``` clojure
@@ -1003,13 +1014,13 @@ See also: [`creation-time`](#babashka.fs/creation-time)
 ```
 Function.
 
-Sets last modified `time` of `path`. 
+Sets last modified `time` of `path`.
 `time` can be `epoch milliseconds`,
 [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html),
 or [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html).
 
 See also: [`last-modified-time`](#babashka.fs/last-modified-time)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L995-L1005">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1006-L1016">Source</a></sub></p>
 
 ## <a name="babashka.fs/set-posix-file-permissions">`set-posix-file-permissions`</a>
 ``` clojure
@@ -1021,7 +1032,7 @@ Sets `posix-file-permissions` on `path` via [Files/setPosixFilePermissions](http
 Accepts a string like `"rwx------"` or a set of `PosixFilePermission`.
 
 See also: [`posix-file-permissions`](#babashka.fs/posix-file-permissions)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L551-L557">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L557-L563">Source</a></sub></p>
 
 ## <a name="babashka.fs/size">`size`</a>
 ``` clojure
@@ -1030,7 +1041,7 @@ See also: [`posix-file-permissions`](#babashka.fs/posix-file-permissions)
 Function.
 
 Returns the size of `path` in bytes.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L852-L855">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L864-L867">Source</a></sub></p>
 
 ## <a name="babashka.fs/split-ext">`split-ext`</a>
 ``` clojure
@@ -1039,17 +1050,17 @@ Returns the size of `path` in bytes.
 ```
 Function.
 
-Returns `path` split on extension.
+Splits `path` on extension. Returns `[name ext]`.
 Leading directories in `path` are not processed.
 
 Options:
-* `:ext` - split on specified extension (do not include a leading dot) 
-  
+* `:ext` - split on specified extension (do not include a leading dot)
+
 Examples:
 - `(fs/split-ext "foo.bar.baz")` => `["foo.bar" "baz"]`
 - `(fs/split-ext "foo.bar.baz" {:ext "bar.baz"})`  => `["foo" "bar.baz"]`
 - `(fs/split-ext "foo.bar.baz" {:ext "png"})`  => `["foo.bar.baz" nil]`
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1070-L1095">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1081-L1106">Source</a></sub></p>
 
 ## <a name="babashka.fs/split-paths">`split-paths`</a>
 ``` clojure
@@ -1057,10 +1068,9 @@ Examples:
 ```
 Function.
 
-Returns a vector of paths from paths in `joined-paths` string.
-`joined-paths` is split on OS-specific [`path-separator`](#babashka.fs/path-separator).
+Splits `joined-paths` string into a vector of paths by OS-specific [`path-separator`](#babashka.fs/path-separator).
 On UNIX systems, the separator is `:`, on Microsoft Windows systems it is `;`.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1109-L1114">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1120-L1124">Source</a></sub></p>
 
 ## <a name="babashka.fs/starts-with?">`starts-with?`</a>
 ``` clojure
@@ -1071,7 +1081,7 @@ Function.
 Returns `true` if `this-path` starts with `other-path` via [Path#startsWith](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#startsWith(java.nio.file.Path)).
 
 See also: [`ends-with?`](#babashka.fs/ends-with?)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L581-L586">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L587-L592">Source</a></sub></p>
 
 ## <a name="babashka.fs/str->posix">`str->posix`</a>
 ``` clojure
@@ -1079,12 +1089,12 @@ See also: [`ends-with?`](#babashka.fs/ends-with?)
 ```
 Function.
 
-Returns a set of `PosixFilePermission` for permissions string `s`.
+Converts a string `s` to a set of `PosixFilePermission`.
 
 `s` is a string like `"rwx------"`.
 
-See also [`posix->str`](#babashka.fs/posix->str)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L493-L500">Source</a></sub></p>
+See also: [`posix->str`](#babashka.fs/posix->str)
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L495-L502">Source</a></sub></p>
 
 ## <a name="babashka.fs/strip-ext">`strip-ext`</a>
 ``` clojure
@@ -1093,8 +1103,8 @@ See also [`posix->str`](#babashka.fs/posix->str)
 ```
 Function.
 
-Returns `path` with extension stripped via [`split-ext`](#babashka.fs/split-ext).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1097-L1102">Source</a></sub></p>
+Strips extension from `path` via [`split-ext`](#babashka.fs/split-ext).
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1108-L1113">Source</a></sub></p>
 
 ## <a name="babashka.fs/sym-link?">`sym-link?`</a>
 ``` clojure
@@ -1103,7 +1113,7 @@ Returns `path` with extension stripped via [`split-ext`](#babashka.fs/split-ext)
 Function.
 
 Returns `true` if `path` is a symbolic link via [Files/isSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isSymbolicLink(java.nio.file.Path)).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L781-L784">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L791-L794">Source</a></sub></p>
 
 ## <a name="babashka.fs/temp-dir">`temp-dir`</a>
 ``` clojure
@@ -1112,7 +1122,7 @@ Returns `true` if `path` is a symbolic link via [Files/isSymbolicLink](https://d
 Function.
 
 Returns `java.io.tmpdir` property as path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L652-L655">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L658-L661">Source</a></sub></p>
 
 ## <a name="babashka.fs/touch">`touch`</a>
 ``` clojure
@@ -1121,7 +1131,7 @@ Returns `java.io.tmpdir` property as path.
 ```
 Function.
 
-Update last modified time of `path` to `:time`, creating `path` as a file if it does not exist.
+Updates last modified time of `path` to `:time`, creating `path` as a file if it does not exist.
 
 If `path` is deleted by some other process/thread before `:time` is set,
 a `NoSuchFileException` will be thrown. Callers can, if their use case requires it,
@@ -1130,7 +1140,7 @@ implement their own retry loop.
 Options:
 * `:time` - last modified time (epoch milliseconds, `Instant`, or `FileTime`), defaults to current time
 * [`:nofollow-links`](/README.md#nofollow-links)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1035-L1062">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1046-L1073">Source</a></sub></p>
 
 ## <a name="babashka.fs/unixify">`unixify`</a>
 ``` clojure
@@ -1139,7 +1149,7 @@ Options:
 Function.
 
 Returns `path` as string with Unix-style file separators (`/`).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1580-L1586">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1589-L1595">Source</a></sub></p>
 
 ## <a name="babashka.fs/unzip">`unzip`</a>
 ``` clojure
@@ -1155,12 +1165,12 @@ Unzips `zip-file` to `target-dir` (default `"."`).
  * `:replace-existing` - `true` / `false`: overwrite existing files
  * `:extract-fn` - function that decides if the current `ZipEntry`
    should be extracted. Extraction only occurs if a truthy value is returned (i.e. not nil/false).
-   The function is only called for for files (not directories) with a single map arg:
+   The function is only called for files (not directories) with a single map arg:
    * `:entry` - the current `ZipEntry`
    * `:name` - the name of the `ZipEntry` (result of calling `getName`)
 
 See also: [`zip`](#babashka.fs/zip).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1242-L1280">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1252-L1290">Source</a></sub></p>
 
 ## <a name="babashka.fs/update-file">`update-file`</a>
 ``` clojure
@@ -1174,7 +1184,7 @@ Returns the new contents.
 
 Options:
 * `:charset` - charset of file, default to "utf-8"
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1561-L1578">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1570-L1587">Source</a></sub></p>
 
 ## <a name="babashka.fs/walk-file-tree">`walk-file-tree`</a>
 ``` clojure
@@ -1218,7 +1228,7 @@ Options:
 * `:win-exts` - active on Windows only. Searches for `program` with filename extensions specified in `:win-exts` option.
 If `program` already includes an extension from `:win-exts`, it will be searched as-is first.
 Default is `["com" "exe" "bat" "cmd"]`.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1129-L1182">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1139-L1192">Source</a></sub></p>
 
 ## <a name="babashka.fs/which-all">`which-all`</a>
 ``` clojure
@@ -1228,7 +1238,7 @@ Default is `["com" "exe" "bat" "cmd"]`.
 Function.
 
 Returns a vector of every path to `program` found in ([`exec-paths`](#babashka.fs/exec-paths)). See [`which`](#babashka.fs/which).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1184-L1188">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1194-L1198">Source</a></sub></p>
 
 ## <a name="babashka.fs/windows?">`windows?`</a>
 ``` clojure
@@ -1237,7 +1247,7 @@ Returns a vector of every path to `program` found in ([`exec-paths`](#babashka.f
 Function.
 
 Returns `true` if OS is Windows.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1483-L1486">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1492-L1495">Source</a></sub></p>
 
 ## <a name="babashka.fs/with-temp-dir">`with-temp-dir`</a>
 ``` clojure
@@ -1246,15 +1256,14 @@ Returns `true` if OS is Windows.
 ```
 Macro.
 
-Evaluates body with `temp-dir` bound to the result of `(create-temp-dir
-opts)`.
+Evaluates body with `temp-dir` bound to the result of `(create-temp-dir opts)`.
 
 By default, the `temp-dir` will be removed with [`delete-tree`](#babashka.fs/delete-tree) on exit from the scope.
 
 Options:
-* see [`delete-tree`](#babashka.fs/delete-tree)
-* `:keep` - if `true` does not delete the directory on exit from macro scope. 
-  
+* see [`create-temp-dir`](#babashka.fs/create-temp-dir) for options that control directory creation
+* `:keep` - if `true` does not delete the directory on exit from macro scope.
+
 Example:
 ```
 (with-temp-dir [d]
@@ -1265,7 +1274,7 @@ Example:
 ;; d no longer exists here
 ```
   
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1413-L1443">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1423-L1452">Source</a></sub></p>
 
 ## <a name="babashka.fs/writable?">`writable?`</a>
 ``` clojure
@@ -1298,7 +1307,7 @@ Examples:
 (fs/write-bytes f (.getBytes (String. "foo"))) ;; overwrites + truncates or creates new file
 (fs/write-bytes f (.getBytes (String. "foo")) {:append true})
 ```
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1514-L1538">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1523-L1547">Source</a></sub></p>
 
 ## <a name="babashka.fs/write-lines">`write-lines`</a>
 ``` clojure
@@ -1313,12 +1322,12 @@ Options:
 * `:charset` - (default `"utf-8"`)
 
 Open options:
-* `:create` (default `true`)
-* `:truncate-existing` (default `true`)
-* `:write` (default `true`)
-* `:append` (default `false`)
+* `:create` - (default `true`)
+* `:truncate-existing` - (default `true`)
+* `:write` - (default `true`)
+* `:append` - (default `false`)
 * or any `java.nio.file.StandardOption`.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1540-L1559">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1549-L1568">Source</a></sub></p>
 
 ## <a name="babashka.fs/xdg-cache-home">`xdg-cache-home`</a>
 ``` clojure
@@ -1331,7 +1340,7 @@ Returns path to user-specific non-essential data as described in the [XDG Base D
 
 Uses env-var `XDG_CACHE_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) ".cache")`.
 When provided, appends `app` to the returned path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1618-L1626">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1627-L1635">Source</a></sub></p>
 
 ## <a name="babashka.fs/xdg-config-home">`xdg-config-home`</a>
 ``` clojure
@@ -1344,7 +1353,7 @@ Returns path to user-specific configuration files as described in the [XDG Base 
 
 Uses env-var `XDG_CONFIG_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) ".config")`.
 When provided, appends `app` to the returned path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1608-L1616">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1617-L1625">Source</a></sub></p>
 
 ## <a name="babashka.fs/xdg-data-home">`xdg-data-home`</a>
 ``` clojure
@@ -1357,7 +1366,7 @@ Returns path to user-specific data files as described in the [XDG Base Directory
 
 Uses env-var `XDG_DATA_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) ".local" "share")`.
 When provided, appends `app` to the returned path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1628-L1636">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1637-L1645">Source</a></sub></p>
 
 ## <a name="babashka.fs/xdg-state-home">`xdg-state-home`</a>
 ``` clojure
@@ -1370,7 +1379,7 @@ Returns path to user-specific state files as described in the [XDG Base Director
 
 Uses env-var `XDG_STATE_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) ".local" "state")`.
 When provided, appends `app` to the returned path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1638-L1646">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1647-L1655">Source</a></sub></p>
 
 ## <a name="babashka.fs/zip">`zip`</a>
 ``` clojure
@@ -1386,7 +1395,7 @@ preserved in the zip file. Currently only accepts relative paths.
 Options:
 * `:root` - optional directory to be elided in `zip-file` entries. E.g.: `(fs/zip ["src"] {:root "src"})`
 * `:path-fn` - an optional custom path conversion function.
-A single-arg function called for each file sytem path returning the path to be used for the corresponding zip entry.
+A single-arg function called for each file system path returning the path to be used for the corresponding zip entry.
 
 See also: [`unzip`](#babashka.fs/unzip).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1313-L1342">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1323-L1352">Source</a></sub></p>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Babashka [fs](https://github.com/babashka/fs): file system utility library for C
 
 ## Unreleased
 
+- [#197](https://github.com/babashka/fs/issues/197): docstring review - step 1: consistent arg naming, improved docstrings, added `Coercions and Returns` / `Argument Naming Conventions` sections to README ([@lread](https://github.com/lread))
+- [#254](https://github.com/babashka/fs/issues/254): fix `split-ext` and `extension` on dotfiles with parent dirs (e.g. `foo/.gitignore`)
 - [#232](https://github.com/babashka/fs/issues/232): add `touch` fn ([@lread](https://github.com/lread) & [@borkdude](https://github.com/borkdude))
 - [#242](https://github.com/babashka/fs/issues/242): test: add JDK 26 to CI test matrix ([@lread](https://github.com/lread))
 - [#141](https://github.com/babashka/fs/issues/141): test & document effect of unicode glob bug on macOS with JDK < 26 ([@lread](https://github.com/lread))

--- a/README.md
+++ b/README.md
@@ -66,6 +66,37 @@ For convenience, the above use case is also supported using the `which` function
 
 ## Notes
 
+<!-- note: linked from later section -->
+### Coercions and Returns
+Babashka fs functions automatically coerce input path args from `File`, `Path`, and string.
+
+For example, these are all supported and equivalent:
+```clojure
+(fs/exists? "foo")
+(fs/exists? (java.io.File. "foo"))
+(fs/exists? (.toPath (java.io.File. "foo")))
+```
+
+If you need a specific concrete type for a returned path, you can coerce it like so:
+```clojure
+(str (fs/cwd))
+(fs/path (fs/cwd))
+(fs/file (fs/cwd))
+```
+
+### Argument Naming Conventions
+API argument names describe the value's logical role.
+For example, if an argument name contains:
+
+| Argument Name | Argument Expects  |
+|---------------|-------------------|
+| `path`        | directory or file |
+| `file`        | file              |
+| `dir`         | directory         |
+
+The argument name conveys the logical role of the value you pass; it does not describe its type.
+See [Coercions and Returns](#coercions-and-returns).
+
 ### File Systems & OSes & JDK Bugs
 Behaviour can vary on different file systems and OSes.
 

--- a/src/babashka/fs.cljc
+++ b/src/babashka/fs.cljc
@@ -49,11 +49,11 @@
   (System/getenv k))
 
 (defn path
-  "Coerces arg(s) into a `Path`, combining multiple paths into one.
+  "Returns `path`(s) coerced to a `Path`, combining multiple paths into one.
   Multiple-arg versions treat the first argument as parent and subsequent
   args as children relative to the parent."
-  (^Path [f]
-   (as-path f))
+  (^Path [path]
+   (as-path path))
   (^Path [parent child]
    (if parent
      (if (string? child)
@@ -63,13 +63,15 @@
   (^Path [parent child & more]
    (reduce path (path parent child) more)))
 
+(def ^:private path* "synonym to avoid path arg-name to path fn shadowing conflicts" path)
+
 (defn file
-  "Coerces arg(s) into a `File`, combining multiple paths into one.
+  "Returns `path`(s) coerced to a `File`, combining multiple paths into one.
   Multiple-arg versions treat the first argument as parent and subsequent args
   as children relative to the parent."
-  (^File [f] (as-file f))
-  (^File [f & fs]
-   (apply io/file (map as-file (cons f fs)))))
+  (^File [path] (as-file path))
+  (^File [path & paths]
+   (apply io/file (map as-file (cons path paths)))))
 
 (defn- ->link-opts ^"[Ljava.nio.file.LinkOption;"
   [nofollow-links]
@@ -79,89 +81,89 @@
                 (conj LinkOption/NOFOLLOW_LINKS))))
 
 (defn real-path
-  "Converts `f` into real `Path` via [Path#toRealPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toRealPath(java.nio.file.LinkOption...)).
+  "Returns real path for `path` via [Path#toRealPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toRealPath(java.nio.file.LinkOption...)).
 
   Options:
   * [`:nofollow-links`](/README.md#nofollow-links)"
-  (^Path [f] (real-path f nil))
-  (^Path [f {:keys [:nofollow-links]}]
-   (.toRealPath (as-path f) (->link-opts nofollow-links))))
+  (^Path [path] (real-path path nil))
+  (^Path [path {:keys [:nofollow-links]}]
+   (.toRealPath (as-path path) (->link-opts nofollow-links))))
 
 (defn owner
-  "Returns the owner of file `f` via [Files/getOwner](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getOwner(java.nio.file.Path,java.nio.file.LinkOption...)).
+  "Returns the owner of `path` via [Files/getOwner](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getOwner(java.nio.file.Path,java.nio.file.LinkOption...)).
   Call `str` on return value to get the owner name as a string.
 
   Options:
   * [`:nofollow-links`](/README.md#nofollow-links)"
-  ([f] (owner f nil))
-  ([f {:keys [:nofollow-links]}]
-   (Files/getOwner (as-path f) (->link-opts nofollow-links))))
+  ([path] (owner path nil))
+  ([path {:keys [:nofollow-links]}]
+   (Files/getOwner (as-path path) (->link-opts nofollow-links))))
 
 ;;;; Predicates
 
 (defn regular-file?
-  "Returns true if `f` is a regular file, using [Files/isRegularFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isRegularFile(java.nio.file.Path,java.nio.file.LinkOption...)).
+  "Returns `true` if `path` is a regular file via [Files/isRegularFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isRegularFile(java.nio.file.Path,java.nio.file.LinkOption...)).
 
   Options:
   * [`:nofollow-links`](/README.md#nofollow-links)"
-  ([f] (regular-file? f nil))
-  ([f {:keys [:nofollow-links]}]
-   (Files/isRegularFile (as-path f)
+  ([path] (regular-file? path nil))
+  ([path {:keys [:nofollow-links]}]
+   (Files/isRegularFile (as-path path)
                         (->link-opts nofollow-links))))
 
 (defn directory?
-  "Returns true if `f` is a directory, using [Files/isDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isDirectory(java.nio.file.Path,java.nio.file.LinkOption...)).
+  "Returns `true` if `path` is a directory via [Files/isDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isDirectory(java.nio.file.Path,java.nio.file.LinkOption...)).
 
   Options:
   * [`:nofollow-links`](/README.md#nofollow-links)"
-  ([f] (directory? f nil))
-  ([f {:keys [:nofollow-links]}]
-   (Files/isDirectory (as-path f)
+  ([path] (directory? path nil))
+  ([path {:keys [:nofollow-links]}]
+   (Files/isDirectory (as-path path)
                       (->link-opts nofollow-links))))
 
 (def ^:private simple-link-opts
   (into-array LinkOption []))
 
 (defn- directory-simple?
-  [^Path f] (Files/isDirectory f simple-link-opts))
+  [^Path path] (Files/isDirectory path simple-link-opts))
 
 (defn hidden?
-  "Returns true if `f` is hidden via [Files/isHidden](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isHidden(java.nio.file.Path)).
+  "Returns `true` if `path` is hidden via [Files/isHidden](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isHidden(java.nio.file.Path)).
 
   TIP: some older JDKs can throw on empty-string path `(hidden \"\")`.
   Consider instead checking cwd via `(hidden \".\")`."
-  [f] (Files/isHidden (as-path f)))
+  [path] (Files/isHidden (as-path path)))
 
 (defn absolute?
-  "Returns true if `f` represents an absolute path via [Path#isAbsolute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#isAbsolute())."
-  [f] (.isAbsolute (as-path f)))
+  "Returns `true` if `path` is absolute via [Path#isAbsolute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#isAbsolute())."
+  [path] (.isAbsolute (as-path path)))
 
 (defn executable?
-  "Returns true if `f` has is executable via [Files/isExecutable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isExecutable(java.nio.file.Path))."
-  [f] (Files/isExecutable (as-path f)))
+  "Returns `true` if `path` is executable via [Files/isExecutable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isExecutable(java.nio.file.Path))."
+  [path] (Files/isExecutable (as-path path)))
 
 (defn readable?
-  "Returns true if `f` is readable via [Files/isReadable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isReadable(java.nio.file.Path))"
-  [f] (Files/isReadable (as-path f)))
+  "Returns `true` if `path` is readable via [Files/isReadable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isReadable(java.nio.file.Path))"
+  [path] (Files/isReadable (as-path path)))
 
 (defn writable?
-  "Returns true if `f` is writable via [Files/isWritable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isWritable(java.nio.file.Path))"
-  [f] (Files/isWritable (as-path f)))
+  "Returns `true` if `path` is writable via [Files/isWritable](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isWritable(java.nio.file.Path))"
+  [path] (Files/isWritable (as-path path)))
 
 (defn relative?
-  "Returns true if `f` represents a relative path (in other words, is not [[absolute?]])."
-  [f] (not (absolute? f)))
+  "Returns `true` if `path` is relative (in other words, is not [[absolute?]])."
+  [path] (not (absolute? path)))
 
 (defn exists?
-  "Returns true if `f` exists via [Files/exists](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#exists(java.nio.file.Path,java.nio.file.LinkOption...)).
+  "Returns `true` if `path` exists via [Files/exists](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#exists(java.nio.file.Path,java.nio.file.LinkOption...)).
 
   Options:
   * [`:nofollow-links`](/README.md#nofollow-links)"
-  ([f] (exists? f nil))
-  ([f {:keys [:nofollow-links]}]
+  ([path] (exists? path nil))
+  ([path {:keys [:nofollow-links]}]
    (try
      (Files/exists
-      (as-path f)
+      (as-path path)
       (->link-opts nofollow-links))
      (catch Exception _e
        false))))
@@ -169,40 +171,44 @@
 ;;;; End predicates
 
 (defn components
-  "Returns a seq of all components of `f` as paths.
+  "Returns a seq of paths for all components of `path`.
   i.e.: split on the [[file-separator]]."
-  [f]
-  (seq (as-path f)))
+  [path]
+  (seq (as-path path)))
 
 (defn absolutize
-  "Converts `f` into an absolute `Path` via [Path#toAbsolutePath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toAbsolutePath())."
-  [f] (.toAbsolutePath (as-path f)))
+  "Returns absolute path for `path` via [Path#toAbsolutePath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toAbsolutePath())."
+  [path] (.toAbsolutePath (as-path path)))
 
 (defn relativize
-  "Returns relative `Path` by comparing `this` with `other` via [Path#relativize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#relativize(java.nio.file.Path))."
-  ^Path [this other]
-  (.relativize (as-path this) (as-path other)))
+  "Returns `other-path` relative to `base-path` via [Path#relativize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#relativize(java.nio.file.Path)).
+
+  Examples:
+  - `(fs/relativize \"a/b\" \"a/b/c/d\")` => `c/d`
+  - `(fs/relativize \"a/b/c/d\" \"a/b\")` => `../..`"
+  ^Path [base-path other-path]
+  (.relativize (as-path base-path) (as-path other-path)))
 
 (defn normalize
-  "Returns normalize `Path` for `f` via [Path#normalize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#normalize())."
-  [f]
-  (.normalize (as-path f)))
+  "Returns normalized path for `path` via [Path#normalize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#normalize())."
+  [path]
+  (.normalize (as-path path)))
 
 (defn canonicalize
-  "Returns the canonical `Path` for `f` via [File#getCanonicalPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getCanonicalPath()).
+  "Returns canonical path for `path` via [File#getCanonicalPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getCanonicalPath()).
 
   Options:
-  * [`:nofollow-links`](/README.md#nofollow-links), when set, falls back on [[absolutize]] + [[normalize]].
+  * [`:nofollow-links`](/README.md#nofollow-links) - when set, falls back on [[absolutize]] + [[normalize]].
 
   This function can be used as an alternative to [[real-path]] which requires files to exist."
-  (^Path [f] (canonicalize f nil))
-  (^Path [f {:keys [:nofollow-links]}]
+  (^Path [path] (canonicalize path nil))
+  (^Path [path {:keys [:nofollow-links]}]
    (if nofollow-links
-     (-> f absolutize normalize)
-     (as-path (.getCanonicalPath (as-file f))))))
+     (-> path absolutize normalize)
+     (as-path (.getCanonicalPath (as-file path))))))
 
 (defn root
-  "Returns `root` for `path` as `Path`, or `nil` via [Path#getRoot](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#getRoot()).
+  "Returns root path for `path`, or `nil`, via [Path#getRoot](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#getRoot()).
 
   The return value depends upon the runtime platform.
 
@@ -217,31 +223,31 @@
   (.getRoot (as-path path)))
 
 (defn file-name
-  "Returns the name of the file or directory via [File#getName](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getName()).
-  E.g. (file-name \"foo/bar/baz\") returns \"baz\"."
-  [x]
-  (.getName (as-file x)))
+  "Returns the name of the file or directory for `path` via [File#getName](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getName()).
+  E.g. `(file-name \"foo/bar/baz\")` returns `\"baz\"`."
+  [path]
+  (.getName (as-file path)))
 
 (def ^:private continue (constantly :continue))
 
 (defn walk-file-tree
-  "Walks `f` using [Files/walkFileTree](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#walkFileTree(java.nio.file.Path,java.util.Set,int,java.nio.file.FileVisitor)).
+  "Walks `path` via [Files/walkFileTree](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#walkFileTree(java.nio.file.Path,java.util.Set,int,java.nio.file.FileVisitor)).
 
   Options:
   * [`:follow-links`](/README.md#follow-links)
-  * `:max-depth` maximum directory depth to walk, defaults is unlimited
+  * `:max-depth` - maximum directory depth to walk, defaults is unlimited
   * Override default visitor functions via:
-    * `:pre-visit-dir` args `[dir attrs]`
-    * `:post-visit-dir` args `[dir ex]`
-    * `:visit-file` args `[file attrs]`
-    * `:visit-file-failed` args `[file ex]`
+    * `:pre-visit-dir` - args `[dir attrs]`
+    * `:post-visit-dir` - args `[dir ex]`
+    * `:visit-file` - args `[file attrs]`
+    * `:visit-file-failed` - args `[file ex]`
 
   All visitor functions must return one of `:continue`, `:skip-subtree`, `:skip-siblings` or `:terminate`.
   A different return value will throw. When not supplied, visitor functions default
   to `(constantly :continue)`.
 
-  Returns `f` as `Path`."
-  [f
+  Returns `path`."
+  [path
    {:keys [:pre-visit-dir :post-visit-dir
            :visit-file :visit-file-failed
            :follow-links :max-depth]}]
@@ -254,7 +260,7 @@
         visit-file-failed (or visit-file-failed
                               (fn [_path _attrs]
                                 :continue))]
-    (Files/walkFileTree (as-path f)
+    (Files/walkFileTree (as-path path)
                         visit-opts
                         max-depth
                         (reify FileVisitor
@@ -275,7 +281,7 @@
    (defn- directory-stream
      "Returns a stream of all files in `dir`. The caller of this function is
   responsible for closing the stream, e.g. using `with-open`. The stream
-  can consumed as a seq by calling seq on it. Accepts optional [[glob]] string or
+  can be consumed as a seq by calling seq on it. Accepts optional [[glob]] string or
   accept function of one argument."
      (^DirectoryStream [dir]
       (Files/newDirectoryStream (as-path dir)))
@@ -290,7 +296,8 @@
 
 #?(:bb nil :clj
    (defn list-dir
-     "Returns all paths in `dir` as vector. For descending into subdirectories use [[glob]].
+     "Returns a vector of all paths in `dir`. For descending into subdirectories use [[glob]].
+
      - `glob-or-accept` - a [[glob]] string such as \"*.edn\" or a `(fn accept [^java.nio.file.Path p]) -> truthy`"
      ([dir]
       (with-open [stream (directory-stream dir)]
@@ -307,13 +314,15 @@
    (as-path path)))
 
 (def file-separator
-  "The system-dependent default name-separator character (as string)"
+  "The system-dependent default path component separator character (as string)."
   File/separator)
+
 (def path-separator
   "The system-dependent path-separator character (as string)."
   File/pathSeparator)
 
 (def ^:private win?
+  "`true` if running on Windows Operating System"
   (-> (System/getProperty "os.name")
       (str/lower-case)
       (str/includes? "win")))
@@ -334,30 +343,29 @@
   (java.util.regex.Pattern/quote s))
 
 (defn match
-  "Returns a vector of paths matching `pattern` (on path and filename) relative to `root` dir.
+  "Returns a vector of paths matching `pattern` (on path and filename) relative to `root-dir`.
   Pattern interpretation is done using the rules described in
   [FileSystem#getPathMatcher](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String))
 
   Options:
-
   * `:hidden` - match hidden paths - note: on Windows paths starting with
   a dot are not hidden, unless their hidden attribute is set. Defaults to
   `false`, i.e. skip hidden files and folders.
   * [`:follow-links`](/README.md#follow-links) - follow symlinks. Defaults to false.
   * `:recursive`
-    * `true`, `pattern` is matched against all descendant files and directories under `root`
-    * `false` (default), `pattern` is matched only against immediate children under `root`
+    * `true` - `pattern` is matched against all descendant files and directories under `root`
+    * `false` (default) - `pattern` is matched only against immediate children under `root`
   * `:max-depth` - max depth to descend into directory structure, when
   matching recursively. Defaults to `Integer/MAX_VALUE`.
 
   Examples: 
   - `(fs/match \".\" \"regex:.*\\\\.clj\" {:recursive true})`
 
-  See also: [[glob]]" 
-  ([root pattern] (match root pattern nil))
-  ([root pattern {:keys [hidden follow-links max-depth recursive]}]
+  See also: [[glob]]"
+  ([root-dir pattern] (match root-dir pattern nil))
+  ([root-dir pattern {:keys [hidden follow-links max-depth recursive]}]
    (let [[prefix pattern] (str/split pattern #":")
-         base-path (-> root absolutize normalize str)
+         base-path (-> root-dir absolutize normalize str)
          escaped-base-path (case prefix
                              "glob" (escape-glob-chars base-path)
                              "regex" (escape-regex-chars base-path)
@@ -403,26 +411,25 @@
                      :continue)})
      (let [results (persistent! @results)
            absolute-cwd (absolutize "")]
-       (if (relative? root)
+       (if (relative? root-dir)
          (mapv #(relativize absolute-cwd %)
                results)
          results)))))
 
 (defn glob
-  "Returns a vector of paths matching glob `pattern` (on path and filename) relative to `root` dir.
+  "Returns a vector of paths matching glob `pattern` (on path and filename) relative to `root-dir`.
   Patterns containing `**` or `/` will cause a recursive walk under
-  `root`, unless overriden with `:recursive false`. Similarly, `:hidden` will be automaticaly enabled 
+  `root-dir`, unless overriden with `:recursive false`. Similarly, `:hidden` will be automaticaly enabled 
   when `pattern` starts with a dot.
   Glob interpretation is done using the rules described in
   [FileSystem#getPathMatcher](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String))
 
   Options:
-
   * `:hidden` - match hidden paths. Implied `true` when `pattern` starts with a dot;
   otherwise, defaults to `false`. Note: on Windows files starting with a dot are
   not hidden, unless their hidden attribute is set.
   * [`:follow-links`](/README.md#follow-links) - follow symlinks. Defaults to `false`.
-  * `:recursive` - Implied `true` when `pattern` contains `**` or `/`; otherwise, defaults to `false`.
+  * `:recursive` - implied `true` when `pattern` contains `**` or `/`; otherwise, defaults to `false`.
     * `true` - `pattern` is matched against all descendant files and directories under `root`
     * `false` - `pattern` is matched only against immediate children under `root`
   * `:max-depth` - max depth to descend into directory structure, when
@@ -436,15 +443,15 @@
   If on macOS, see [note on glob](/README.md#glob)
 
   See also: [[match]]"
-  ([root pattern] (glob root pattern nil))
-  ([root pattern opts]
+  ([root-dir pattern] (glob root-dir pattern nil))
+  ([root-dir pattern opts]
    (let [recursive (:recursive opts
                                (or (str/includes? pattern "**")
                                    (str/includes? pattern file-separator)
                                    (when win?
                                      (str/includes? pattern "/"))))
          hidden    (:hidden opts (str/starts-with? pattern "."))]
-     (match root (str "glob:" pattern) (assoc opts :recursive recursive :hidden hidden)))))
+     (match root-dir (str "glob:" pattern) (assoc opts :recursive recursive :hidden hidden)))))
 
 (defn- ->copy-opts ^"[Ljava.nio.file.CopyOption;"
   [replace-existing copy-attributes atomic-move nofollow-links]
@@ -456,36 +463,39 @@
                 nofollow-links   (conj LinkOption/NOFOLLOW_LINKS))))
 
 (defn copy
-  "Copies `src` file to `dest` dir or file using [Files/copy](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#copy(java.nio.file.Path,java.nio.file.Path,java.nio.file.CopyOption...)).
+  "Copies `source-file` to `target-path` dir or file via [Files/copy](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#copy(java.nio.file.Path,java.nio.file.Path,java.nio.file.CopyOption...)).
 
   Options:
   * `:replace-existing`
   * `:copy-attributes`
-  * [`:nofollow-links`](/README.md#nofollow-links) (used to determine to copy symbolic link itself or not).
-  Returns `dest` as path."
-  ([src dest] (copy src dest nil))
-  ([src dest {:keys [replace-existing
-                     copy-attributes
-                     nofollow-links]}]
+  * [`:nofollow-links`](/README.md#nofollow-links) - used to determine to copy symbolic link itself or not."
+  ([source-file target-path] (copy source-file target-path nil))
+  ([source-file target-path {:keys [replace-existing
+                                    copy-attributes
+                                    nofollow-links]}]
    (let [copy-options (->copy-opts replace-existing copy-attributes false nofollow-links)
-         dest (as-path dest)
+         dest (as-path target-path)
          dest (if (directory-simple? dest)
-                (path dest (file-name src))
+                (path dest (file-name source-file))
                 dest)
-         input-stream? (instance? java.io.InputStream src)]
+         input-stream? (instance? java.io.InputStream source-file)]
      (if input-stream?
-       (Files/copy ^java.io.InputStream src dest copy-options)
-       (Files/copy (as-path src) dest copy-options)))))
+       (Files/copy ^java.io.InputStream source-file dest copy-options)
+       (Files/copy (as-path source-file) dest copy-options)))))
 
 (defn posix->str
-  "Converts a set of `PosixFilePermission` `p` to a string."
+  "Returns permissions string, like `\"rwx------\"`, for a set of `PosixFilePermission` `p`.
+
+  See also [[str->posix]]"
   [p]
   (PosixFilePermissions/toString p))
 
 (defn str->posix
-  "Converts a string `s` to a set of `PosixFilePermission`.
+  "Returns a set of `PosixFilePermission` for permissions string `s`.
 
-  `s` is a string like `\"rwx------\"`."
+  `s` is a string like `\"rwx------\"`.
+
+  See also [[posix->str]]"
   [s]
   (PosixFilePermissions/fromString s))
 
@@ -511,46 +521,52 @@
     (into-array FileAttribute attrs)))
 
 (defn create-dir
-  "Creates dir using [Files/createDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectory(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+  "Returns new `dir` created via [Files/createDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectory(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
   Does not create parents.
 
-  Returns created directory as `Path`.
-
   Options:
-  * `:posix-file-permissions` permission for unix-like systems, affected by [umask](/README.md#umask)"
-  ([path]
-   (create-dir path nil))
-  ([path {:keys [:posix-file-permissions]}]
+  * `:posix-file-permissions` - string format for unix-like system permissions for `dir`, as described in [[str->posix]].
+  Affected by [umask](/README.md#umask)."
+  ([dir]
+   (create-dir dir nil))
+  ([dir {:keys [:posix-file-permissions]}]
    (let [attrs (posix->attrs posix-file-permissions)]
-     (Files/createDirectory (as-path path) attrs))))
+     (Files/createDirectory (as-path dir) attrs))))
 
 (defn create-dirs
-  "Creates directories for `path` using [Files/createDirectories](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectories(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+  "Returns `dir` after creating directories for `dir` via [Files/createDirectories](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectories(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
   Also creates parents if needed.
-  Doesn't throw an exception if the dirs exist already. Similar to `mkdir -p`
-
+  Does not throw an exception if the dirs exist already. Similar to `mkdir -p` shell command.
+  
   Options:
-  * `:posix-file-permissions` permission for unix-like systems, affected by [umask](/README.md#umask)"
-  ([path] (create-dirs path nil))
-  ([path {:keys [:posix-file-permissions]}]
-   (let [p (as-path path)]
+  * `:posix-file-permissions` - string format for unix-like system permissions for `dir`, as described in [[str->posix]].
+  Affected by [umask](/README.md#umask)."
+  ([dir] (create-dirs dir nil))
+  ([dir {:keys [:posix-file-permissions]}]
+   (let [p (as-path dir)]
      (if (directory? p) ;; compensate for JDK11 which does not follow symlinks in its createDirectories
        p
-       (Files/createDirectories (as-path path) (posix->attrs posix-file-permissions))))))
+       (Files/createDirectories (as-path dir) (posix->attrs posix-file-permissions))))))
 
 (defn set-posix-file-permissions
-  "Sets `posix-file-permissions` on `f`. Accepts a string like `\"rwx------\"` or a set of `PosixFilePermission`."
-  [f posix-file-permissions]
-  (Files/setPosixFilePermissions (as-path f) (->posix-file-permissions posix-file-permissions)))
+  "Sets `posix-file-permissions` on `path` via [Files/setPosixFilePermissions](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#setPosixFilePermissions(java.nio.file.Path,java.util.Set)).
+  Accepts a string like `\"rwx------\"` or a set of `PosixFilePermission`.
+
+  See also: [[posix-file-permissions]]"
+  [path posix-file-permissions]
+  (Files/setPosixFilePermissions (as-path path) (->posix-file-permissions posix-file-permissions)))
 
 (defn posix-file-permissions
-  "Returns posix file permissions for `f`. Use [[posix->str]] to view as a string.
+  "Returns a set of `PosixFilePermissions` for `path` via [Files/getPosixFilePermissions](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getPosixFilePermissions(java.nio.file.Path,java.nio.file.LinkOption...)).
+  Use [[posix->str]] to convert to a string.
 
   Options:
-  * [`:nofollow-links`](/README.md#nofollow-links)"
-  ([f] (posix-file-permissions f nil))
-  ([f {:keys [:nofollow-links]}]
-   (Files/getPosixFilePermissions (as-path f) (->link-opts nofollow-links))))
+  * [`:nofollow-links`](/README.md#nofollow-links)
+
+  See also: [[set-posix-file-permissions]]"
+  ([path] (posix-file-permissions path nil))
+  ([path {:keys [:nofollow-links]}]
+   (Files/getPosixFilePermissions (as-path path) (->link-opts nofollow-links))))
 
 (defn- u+wx
   [f]
@@ -563,48 +579,50 @@
         (set-posix-file-permissions f perms)))))
 
 (defn starts-with?
-  "Returns `true` if path `this` starts with path `other` via [Path#startsWith](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#startsWith(java.nio.file.Path)).
+  "Returns `true` if `this-path` starts with `other-path` via [Path#startsWith](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#startsWith(java.nio.file.Path)).
 
   See also: [[ends-with?]]"
-  [this other]
-  (.startsWith (as-path this) (as-path other)))
+  [this-path other-path]
+  (.startsWith (as-path this-path) (as-path other-path)))
 
 (defn ends-with?
-  "Returns `true` if path `this` ends with path `other` via [Path#endsWith](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#endsWith(java.nio.file.Path)).
+  "Returns `true` if `this-path` ends with `other-path` via [Path#endsWith](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#endsWith(java.nio.file.Path)).
 
   See also: [[starts-with?]]"
-  [this other]
-  (.endsWith (as-path this) (as-path other)))
+  [this-path other-path]
+  (.endsWith (as-path this-path) (as-path other-path)))
 
 (defn copy-tree
-  "Copies entire file tree from `src` to `dest`. Creates `dest` if needed
-  using [[create-dirs]], passing it the `:posix-file-permissions`
-  option. Supports same options as [[copy]]."
-  ([src dest] (copy-tree src dest nil))
-  ([src dest {:keys [:replace-existing
-                     :copy-attributes
-                     :nofollow-links]
-              :as opts}]
+  "Copies entire file tree from `source-dir` to `target-dir`. Creates `target-dir` if needed.
+ 
+  Options:
+  * same as [[copy]]
+  * `:posix-file-permissions` - string format unix-like system permissions passed to [[create-dirs]] when creating `target-dir`."
+  ([source-dir target-dir] (copy-tree source-dir target-dir nil))
+  ([source-dir target-dir {:keys [:replace-existing
+                                  :copy-attributes
+                                  :nofollow-links]
+                           :as opts}]
    ;; cf. Python
-   (when-not (directory? src opts)
-     (throw (IllegalArgumentException. (str "Not a directory: " src))))
+   (when-not (directory? source-dir opts)
+     (throw (IllegalArgumentException. (str "Not a directory: " source-dir))))
    ;; cf. Python
-   (when (and (exists? dest opts)
-              (not (directory? dest opts)))
-     (throw (IllegalArgumentException. (str "Not a directory: " dest))))
+   (when (and (exists? target-dir opts)
+              (not (directory? target-dir opts)))
+     (throw (IllegalArgumentException. (str "Not a directory: " target-dir))))
    ;; cf. Python
-   (let [csrc (canonicalize src)
-         cdest (canonicalize dest)]
+   (let [csrc (canonicalize source-dir)
+         cdest (canonicalize target-dir)]
      (when (and (not= csrc cdest)
                 (starts-with? cdest csrc))
        (throw (Exception. (format "Cannot copy src directory: %s, under itself to dest: %s"
-                                  (str src) (str dest))))))
-   (create-dirs dest opts)
+                                  (str source-dir) (str target-dir))))))
+   (create-dirs target-dir opts)
    (let [copy-options (->copy-opts replace-existing copy-attributes false nofollow-links)
          link-options (->link-opts nofollow-links)
-         from (real-path src {:nofollow-links nofollow-links})
+         from (real-path source-dir {:nofollow-links nofollow-links})
          ;; using canonicalize here because real-path requires the path to exist
-         to (canonicalize dest {:nofollow-links nofollow-links})]
+         to (canonicalize target-dir {:nofollow-links nofollow-links})]
      (walk-file-tree from {:pre-visit-dir (fn [dir _attrs]
                                             (let [rel (relativize from dir)
                                                   to-dir (path to rel)]
@@ -637,22 +655,21 @@
   (as-path (System/getProperty "java.io.tmpdir")))
 
 (defn create-temp-dir
-  "Creates a directory using [Files/createTempDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createTempDirectory(java.nio.file.Path,java.lang.String,java.nio.file.attribute.FileAttribute...)).
+  "Returns path to directory created via [Files/createTempDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createTempDirectory(java.nio.file.Path,java.lang.String,java.nio.file.attribute.FileAttribute...)).
 
   This function does not set up any automatic deletion of the directories it
   creates. See [[with-temp-dir]] for that functionality.
 
   Options:
-  * `:dir`: Directory in which to create the new directory. Defaults to default
+  * `:dir` - directory in which to create the new directory. Defaults to default
   system temp dir (e.g. `/tmp`); see [[temp-dir]]. Must already exist.
-  * `:prefix`: Provided as a hint to the process that generates the name of the
+  * `:prefix` - provided as a hint to the process that generates the name of the
   new directory. In most cases, this will be the beginning of the new directory
   name. Defaults to a random (v4) UUID.
-  * `:posix-file-permissions`: The new directory will be created with these
-  permissions, given as a String as described in [[str->posix]]. If not
-  specified, uses the file system default permissions for new directories.
+  * `:posix-file-permissions` - string format unix-like system permissions as described in [[str->posix]] for new directory.
+  If not specified, uses the file system default permissions for new directories.
   Affected by [umask](/README.md#umask).
-  * :warning: `:path` **[DEPRECATED]** Previous name for `:dir`, kept
+  * :warning: `:path` - **[DEPRECATED]** previous name for `:dir`, kept
   for backwards compatibility. If both `:path` and `:dir` are given (don't do
   that!), `:dir` is used.
 
@@ -676,25 +693,24 @@
         attrs)))))
 
 (defn create-temp-file
-  "Creates an empty file using [Files/createTempFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createTempFile(java.nio.file.Path,java.lang.String,java.lang.String,java.nio.file.attribute.FileAttribute...)).
+  "Returns path to empty file created via [Files/createTempFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createTempFile(java.nio.file.Path,java.lang.String,java.lang.String,java.nio.file.attribute.FileAttribute...)).
 
   This function does not set up any automatic deletion of the files it
   creates. Create the file in a [[with-temp-dir]] for that functionality.
 
   Options:
-  * `:dir`: Directory in which to create the new file. Defaults to default
+  * `:dir` - directory in which to create the new file. Defaults to default
   system temp dir (e.g. `/tmp`); see [[temp-dir]]. Must already exist.
-  * `:prefix`: Provided as a hint to the process that generates the name of the
+  * `:prefix` - provided as a hint to the process that generates the name of the
   new file. In most cases, this will be the beginning of the new file name.
   Defaults to a random (v4) UUID.
-  * `:suffix`: Provided as a hint to the process that generates the name of the
+  * `:suffix` - provided as a hint to the process that generates the name of the
   new file. In most cases, this will be the end of the new file name.
   Defaults to a random (v4) UUID.
-  * `:posix-file-permissions`: The new file will be created with these
-  permissions, given as a String as described in [[str->posix]]. If not
-  specified, uses the file system default permissions for new files.
+  * `:posix-file-permissions` - string format unix-like system permissions for new file, as described in [[str->posix]].
+  If not specified, uses the file system default permissions for new files.
   Affected by [umask](/README.md#umask).
-  * :warning: `:path` **[DEPRECATED]** Previous name for `:dir`, kept
+  * :warning: `:path` - **[DEPRECATED]** Previous name for `:dir`, kept
   for backwards compatibility. If both `:path` and `:dir` are given (don't do
   that!), `:dir` is used.
 
@@ -723,59 +739,61 @@
         attrs)))))
 
 (defn create-sym-link
-  "Create a symbolic `link` to `target` via [Files/createSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createSymbolicLink(java.nio.file.Path,java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+  "Returns new symbolic `link` to `target-path` created via [Files/createSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createSymbolicLink(java.nio.file.Path,java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
 
-  As of this writing, JDKs do not recognize empty-string `target` `\"\"` as the cwd.
-  Consider instead using a `target` of `\".\"` to link to the cwd."
-  [link target]
+  As of this writing, JDKs do not recognize empty-string `target-path` `\"\"` as the cwd.
+  Consider instead using a `target-path` of `\".\"` to link to the cwd."
+  [link target-path]
   (Files/createSymbolicLink
    (as-path link)
-   (as-path target)
+   (as-path target-path)
    (make-array FileAttribute 0)))
 
 (defn create-link
-  "Create a new `link` (directory entry) for an `existing` file via [Files/createLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createLink(java.nio.file.Path,java.nio.file.Path))."
-  [link existing]
+  "Returns a new hard `link` (directory entry) for an `existing-file` created via [Files/createLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createLink(java.nio.file.Path,java.nio.file.Path))."
+  [link existing-file]
   (Files/createLink
    (as-path link)
-   (as-path existing)))
+   (as-path existing-file)))
 
 (defn read-link
-  "Reads the target of a symbolic link `path` via [Files/readSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readSymbolicLink(java.nio.file.Path)).
+  "Returns the immediate target of `sym-link-path` via [Files/readSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readSymbolicLink(java.nio.file.Path)).
   The target need not exist."
-  [path]
-  (java.nio.file.Files/readSymbolicLink (as-path path)))
+  [sym-link-path]
+  (java.nio.file.Files/readSymbolicLink (as-path sym-link-path)))
 
 (defn delete
-  "Deletes `f` using [Files/delete](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#delete(java.nio.file.Path)).
+  "Deletes `path` via [Files/delete](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#delete(java.nio.file.Path)).
   Returns `nil` if the delete was successful,
   throws otherwise. Does not follow symlinks."
   ;; We don't follow symlinks, since the link can target a dir and you should be
   ;; using delete-tree to delete that.
-  [f]
-  (Files/delete (as-path f)))
+  [path]
+  (Files/delete (as-path path)))
 
 (defn delete-if-exists
-  "Deletes `f` if it exists via [Files/deleteIfExists](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#deleteIfExists(java.nio.file.Path)).
+  "Deletes `path` if it exists via [Files/deleteIfExists](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#deleteIfExists(java.nio.file.Path)).
   Returns `true` if the delete was successful,
-  `false` if `f` didn't exist. Does not follow symlinks."
-  [f]
-  (Files/deleteIfExists (as-path f)))
+  `false` if `path` didn't exist. Does not follow symlinks."
+  [path]
+  (Files/deleteIfExists (as-path path)))
 
 (defn sym-link?
-  "Determines if `f` is a symbolic link via [Files/isSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isSymbolicLink(java.nio.file.Path))."
-  [f]
-  (Files/isSymbolicLink (as-path f)))
+  "Returns `true` if `path` is a symbolic link via [Files/isSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isSymbolicLink(java.nio.file.Path))."
+  [path]
+  (Files/isSymbolicLink (as-path path)))
 
 (defn delete-tree
-  "Deletes a file tree `root` using [[walk-file-tree]]. Similar to `rm -rf`. Does not follow symlinks.
-   `force` ensures read-only directories/files are deleted. Similar to `chmod -R +wx` + `rm -rf`"
+  "Deletes the file tree at `root-path` using [[walk-file-tree]]. Similar to `rm -rf` shell command. Does not follow symlinks.
+
+  Options:
+  * `:force` - if `true` forces deletion of read-only files/directories. Similar to `chmod -R +wx` + `rm -rf` shell commands."
   ;; See: delete-permissions-* tests
   ;; Implementation with the force flag is based on assumptions in those tests
-  ([root] (delete-tree root nil))
-  ([root {:keys [force]}]
-   (when (exists? root {:nofollow-links true})
-     (walk-file-tree root
+  ([root-path] (delete-tree root-path nil))
+  ([root-path {:keys [force]}]
+   (when (exists? root-path {:nofollow-links true})
+     (walk-file-tree root-path
                      {:visit-file (fn [path _]
                                     (when (and win? force)
                                       (.setWritable (file path) true))
@@ -790,67 +808,69 @@
                                         :continue)}))))
 
 (defn create-file
-  "Creates empty file at `path` using [Files/createFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createFile(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+  "Returns new empty `file` created via [Files/createFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createFile(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
 
   Options:
-  * `:posix-file-permissions` string format for posix file permissions is described in the [[str->posix]] docstring."
-  ([path]
-   (create-file path nil))
-  ([path {:keys [:posix-file-permissions]}]
+  * `:posix-file-permissions` - string format for unix-like system permissions for `file`, as described in [[str->posix]].
+  Affected by [umask](/README.md#umask)."
+  ([file]
+   (create-file file nil))
+  ([file {:keys [:posix-file-permissions]}]
    (let [attrs (posix->attrs posix-file-permissions)]
-     (Files/createFile (as-path path) attrs))))
+     (Files/createFile (as-path file) attrs))))
 
 (defn move
-  "Move or rename dir or file `source` to `target` dir or file via [Files/move](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#move(java.nio.file.Path,java.nio.file.Path,java.nio.file.CopyOption...)).
-  If `target` is a directory, moves `source` under `target`.
+  "Moves or renames dir or file at `source-path` to `target-path` dir or file via [Files/move](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#move(java.nio.file.Path,java.nio.file.Path,java.nio.file.CopyOption...)).
+  If `target-path` is a directory, moves `source-path` under `target-path`.
   Never follows symbolic links.
 
-  Returns `target` as `Path`.
+  Returns `target-path` path.
 
   Options:
-  * `replace-existing` - overwrite existing `target`, default `false`
-  * `atomic-move` - watchers will only see complete `target` file, default `false`"
-  ([source target] (move source target nil))
-  ([source target {:keys [:replace-existing
-                          :atomic-move]}]
-   (let [target (as-path target)
+  * `replace-existing` - overwrite existing `target-path`, default `false`
+  * `atomic-move` - watchers will only see complete `target-path` file, default `false`"
+  ([source-path target-path] (move source-path target-path nil))
+  ([source-path target-path {:keys [:replace-existing
+                                    :atomic-move]}]
+   (let [target (as-path target-path)
          nofollow-links true
          link-opts (->link-opts nofollow-links)]
      (if (Files/isDirectory target link-opts)
-       (Files/move (as-path source)
-                   (path target (file-name source))
+       (Files/move (as-path source-path)
+                   (path target (file-name source-path))
                    (->copy-opts replace-existing false atomic-move nofollow-links))
-       (Files/move (as-path source)
+       (Files/move (as-path source-path)
                    target
                    (->copy-opts replace-existing false atomic-move nofollow-links))))))
 
 (defn parent
-  "Returns parent of `f`. Akin to `dirname` in bash."
-  [f]
-  (.getParent (as-path f)))
+  "Returns parent path of `path` via [Paths/getParent](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#getParent()).
+  Akin to `dirname` in bash."
+  [path]
+  (.getParent (as-path path)))
 
 (defn size
-  "Returns the size of a file (in bytes)."
-  [f]
-  (Files/size (as-path f)))
+  "Returns the size of `path` in bytes."
+  [path]
+  (Files/size (as-path path)))
 
 (defn delete-on-exit
-  "Requests delete of file `f` on exit via [File#deleteOnExit](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#deleteOnExit()).
-  Returns `f` unaltered."
-  [f]
-  (.deleteOnExit (as-file f))
-  f)
+  "Requests delete of `path` on exit via [File#deleteOnExit](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#deleteOnExit()).
+  Returns `path`."
+  [path]
+  (.deleteOnExit (as-file path))
+  path)
 
 (defn same-file?
-  "Returns `true` if `this` is the same file as `other` via [Files/isSamefile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isSameFile(java.nio.file.Path,java.nio.file.Path))."
-  [this other]
-  (Files/isSameFile (as-path this) (as-path other)))
+  "Returns `true` if `this-path` is the same file as `other-path` via [Files/isSamefile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#isSameFile(java.nio.file.Path,java.nio.file.Path))."
+  [this-path other-path]
+  (Files/isSameFile (as-path this-path) (as-path other-path)))
 
 (defn read-all-bytes
-  "Returns contents of file `f` as byte array via [Files/readAllBytes](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllBytes(java.nio.file.Path))."
+  "Returns contents of `file` as byte array via [Files/readAllBytes](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllBytes(java.nio.file.Path))."
   ^bytes
-  [f]
-  (Files/readAllBytes (as-path f)))
+  [file]
+  (Files/readAllBytes (as-path file)))
 
 (defn- ->charset ^Charset [charset]
   (if (string? charset)
@@ -858,19 +878,22 @@
     charset))
 
 (defn read-all-lines
-  "Read all lines from a file `f` via [Files/readAllLines](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllLines(java.nio.file.Path,java.nio.charset.Charset))."
-  ([f]
-   (vec (Files/readAllLines (as-path f))))
-  ([f {:keys [charset]
-       :or {charset "utf-8"}}]
+  "Return contents of `file` as a vector of lines via [Files/readAllLines](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllLines(java.nio.file.Path,java.nio.charset.Charset)).
+
+  Options:
+  - `:charset` - defaults to `\"utf-8\"`"
+  ([file]
+   (vec (Files/readAllLines (as-path file))))
+  ([file {:keys [charset]
+          :or {charset "utf-8"}}]
    (vec (Files/readAllLines
-         (as-path f)
+         (as-path file)
          (->charset charset)))))
 
 ;;;; Attributes, from github.com/corasaurus-hex/fs
 
 (defn get-attribute
-  "Return `attribute` for `path` via [Files/getAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getAttribute(java.nio.file.Path,java.lang.String,java.nio.file.LinkOption...))
+  "Returns `attribute` for `path` via [Files/getAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getAttribute(java.nio.file.Path,java.lang.String,java.nio.file.LinkOption...)).
 
   Options:
   * [`:nofollow-links`](/README.md#nofollow-links)"
@@ -887,7 +910,7 @@
     (walk/postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m)))
 
 (defn read-attributes*
-  "Reads `attributes` for `path` via [Files/readAttributes](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAttributes(java.nio.file.Path,java.lang.Class,java.nio.file.LinkOption...)).
+  "Returns requested `attributes` for `path` via [Files/readAttributes](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAttributes(java.nio.file.Path,java.lang.Class,java.nio.file.LinkOption...)).
 
   Options:
   * [`:nofollow-links`](/README.md#nofollow-links)"
@@ -908,8 +931,11 @@
      attrs)))
 
 (defn read-attributes
-  "Same as [[read-attributes*]] but turns `attributes` for `path` into a map and keywordizes keys.
-  Keywordizing can be changed by passing a `:key-fn` in the `opts` map."
+  "Same as [[read-attributes*]] but returns requested `attributes` for `path` as a map with keywordized attribute keys.
+
+  Options:
+  * `:key-fn` - optionally override keywordizing function with your own.
+  * [`:nofollow-links`](/README.md#nofollow-links)"
   ([path attributes]
    (read-attributes path attributes nil))
   ([path attributes {:keys [:nofollow-links :key-fn] :as opts}]
@@ -918,7 +944,7 @@
         (keyize (or key-fn keyword)))))
 
 (defn set-attribute
-  "Set `attribute` for `path` to `value` via [Files/setAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#setAttribute(java.nio.file.Path,java.lang.String,java.lang.Object,java.nio.file.LinkOption...))"
+  "Sets `attribute` for `path` to `value` via [Files/setAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#setAttribute(java.nio.file.Path,java.lang.String,java.lang.Object,java.nio.file.LinkOption...))"
   ([path attribute value]
    (set-attribute path attribute value nil))
   ([path attribute value {:keys [:nofollow-links]}]
@@ -928,25 +954,26 @@
                        (->link-opts nofollow-links))))
 
 (defn file-time->instant
-  "Converts `ft` [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)
-  to an [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html)."
+  "Returns [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html) `ft`
+  as [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html)."
   [^FileTime ft]
   (.toInstant ft))
 
 (defn instant->file-time
-  "Converts `instant` [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html)
-  to a [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)."
+  "Returns [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html) `instant`
+  as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)."
   [instant]
   (FileTime/from instant))
 
 (defn file-time->millis
-  "Converts `ft` [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)
-   to epoch millis (long)."
+  "Returns [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html) `ft`
+  as epoch milliseconds (long)."
   [^FileTime ft]
   (.toMillis ft))
 
 (defn millis->file-time
-  "Converts epoch millis (long) to a [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)."
+  "Returns epoch milliseconds (long)
+  as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)"
   [millis]
   (FileTime/fromMillis millis))
 
@@ -957,49 +984,63 @@
         :else (throw (ex-info "Unrecognized time type" {}))))
 
 (defn last-modified-time
-  "Returns last modified time of `f` as a [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)."
-  ([f]
-   (last-modified-time f nil))
-  ([f {:keys [nofollow-links] :as opts}]
-   (get-attribute f "basic:lastModifiedTime" opts)))
+  "Returns last modified time of `path` as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
+
+  See also: [[set-last-modified-time]], [[creation-time]], [[file-time->instant]], [[file-time->millis]]"
+  ([path]
+   (last-modified-time path nil))
+  ([path {:keys [nofollow-links] :as opts}]
+   (get-attribute path "basic:lastModifiedTime" opts)))
 
 (defn set-last-modified-time
-  "Sets last modified time of `f` to `time` (`epoch millis` or [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html))."
-  ([f time]
-   (set-last-modified-time f time nil))
-  ([f time {:keys [nofollow-links] :as opts}]
-   (set-attribute f "basic:lastModifiedTime" (->file-time time) opts)))
+  "Sets last modified `time` of `path`. 
+  `time` can be `epoch milliseconds`,
+  [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html),
+  or [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html).
+
+  See also: [[last-modified-time]]"
+  ([path time]
+   (set-last-modified-time path time nil))
+  ([path time {:keys [nofollow-links] :as opts}]
+   (set-attribute path "basic:lastModifiedTime" (->file-time time) opts)))
 
 (defn creation-time
-  "Returns creation time of `f` as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
+  "Returns creation time of `path` as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html).
 
-  See [README notes](/README.md#creation-time) for some details on behaviour."
-  ([f]
-   (creation-time f nil))
-  ([f {:keys [nofollow-links] :as opts}]
-   (get-attribute f "basic:creationTime" opts)))
+  See [README notes](/README.md#creation-time) for some details on behaviour.
+
+  See also: [[set-creation-time]], [[last-modified-time]], [[file-time->instant]], [[file-time->millis]]"
+  ([path]
+   (creation-time path nil))
+  ([path {:keys [nofollow-links] :as opts}]
+   (get-attribute path "basic:creationTime" opts)))
 
 (defn set-creation-time
-  "Sets creation time of `f` to time (`epoch millis` or [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)).
+  "Sets creation `time` of `path`.
+  `time` can be `epoch milliseconds`,
+  [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html),
+  or [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html) .
 
   Options:
   * [`:nofollow-links`](/README.md#nofollow-links)
 
-  See [README notes](/README.md#set-creation-time) for some details on behaviour."
-  ([f time]
-   (set-creation-time f time nil))
-  ([f time {:keys [nofollow-links] :as opts}]
-   (set-attribute f "basic:creationTime" (->file-time time) opts)))
+  See [README notes](/README.md#set-creation-time) for some details on behaviour.
+
+  See also: [[creation-time]]"
+  ([path time]
+   (set-creation-time path time nil))
+  ([path time {:keys [nofollow-links] :as opts}]
+   (set-attribute path "basic:creationTime" (->file-time time) opts)))
 
 (defn touch
-  "Update last modified time of `path` to `:time`, creating `path` as file if it does not exist.
+  "Update last modified time of `path` to `:time`, creating `path` as a file if it does not exist.
 
   If `path` is deleted by some other process/thread before `:time` is set,
   a `NoSuchFileException` will be thrown. Callers can, if their use case requires it,
   implement their own retry loop.
 
   Options:
-  * `:time` last modified time (epoch milliseconds, `Instant`, or `FileTime`), defaults to current time
+  * `:time` - last modified time (epoch milliseconds, `Instant`, or `FileTime`), defaults to current time
   * [`:nofollow-links`](/README.md#nofollow-links)"
   ([path]
    (touch path nil))
@@ -1021,15 +1062,22 @@
          (set-last-modified-time path time opts))))))
 
 (defn list-dirs
-  "Similar to list-dir but accepts multiple roots in `dirs` and returns the concatenated results.
+  "Similar to [[list-dir]] but accepts multiple roots in `dirs` and returns the concatenated results.
   - `glob-or-accept` - a [[glob]] string such as `\"*.edn\"` or a `(fn accept [^java.nio.file.Path p]) -> truthy`"
   [dirs glob-or-accept]
   (mapcat #(list-dir % glob-or-accept) dirs))
 
 (defn split-ext
-  "Splits `path` on extension. If provided, a specific extension `ext`, the
-  extension (without dot), will be used for splitting.  Directories
-  are not processed."
+  "Returns `path` split on extension.
+  Leading directories in `path` are not processed.
+
+  Options:
+  * `:ext` - split on specified extension (do not include a leading dot) 
+  
+  Examples:
+  - `(fs/split-ext \"foo.bar.baz\")` => `[\"foo.bar\" \"baz\"]`
+  - `(fs/split-ext \"foo.bar.baz\" {:ext \"bar.baz\"})`  => `[\"foo\" \"bar.baz\"]`
+  - `(fs/split-ext \"foo.bar.baz\" {:ext \"png\"})`  => `[\"foo.bar.baz\" nil]`"
   ([path] (split-ext path nil))
   ([path {:keys [ext]}]
    (let [path-str (str path)
@@ -1047,7 +1095,7 @@
          [path-str nil])))))
 
 (defn strip-ext
-  "Strips extension for `path` via [[split-ext]]."
+  "Returns `path` with extension stripped via [[split-ext]]."
   ([path]
    (strip-ext path nil))
   ([path {:keys [ext] :as opts}]
@@ -1059,35 +1107,37 @@
   (-> path split-ext last))
 
 (defn split-paths
-  "Splits a `joined-paths` list given as a string joined by the OS-specific [[path-separator]] into a vec of paths.
-  On UNIX systems, the separator is ':', on Microsoft Windows systems it is ';'."
+  "Returns a vector of paths from paths in `joined-paths` string.
+  `joined-paths` is split on OS-specific [[path-separator]].
+  On UNIX systems, the separator is `:`, on Microsoft Windows systems it is `;`."
   [^String joined-paths]
   (mapv path (.split joined-paths path-separator)))
 
 (defn exec-paths
-  "Returns executable paths (using the `PATH` environment variable). Same
+  "Returns a vector of command search paths (from the `PATH` environment variable). Same
   as `(split-paths (System/getenv \"PATH\"))`."
   []
   (split-paths (System/getenv "PATH")))
 
 (defn- filename-only?
-  "Returns `true` if `f` is exactly a file name (i.e. with no absolute or
+  "Returns `true` if `path` is exactly a file name (i.e. with no absolute or
   relative path information)."
-  [f]
-  (let [f-as-path (as-path f)]
+  [path]
+  (let [f-as-path (as-path path)]
     (= f-as-path (.getFileName f-as-path))))
 
 (defn which
-  "Returns `Path` to first executable `program` found in `:paths` `opt`, similar to the `which` Unix command.
-  Default for `:paths` is ([[exec-paths]]).
+  "Returns path to first executable `program` found in `:paths`, similar to the `which` Unix command.
 
-  On Windows, searches for `program` with filename extensions specified in `:win-exts` option.
-  Default is `[\"com\" \"exe\" \"bat\" \"cmd\"]`.
+  When `program` is a relative or absolute path, `:paths` option is not consulted.
+  On Windows, the `:win-exts` variants are still searched.
+  On other OSes, the path for `program` will be returned if executable, else `nil`.
+
+  Options:
+  * `:paths` - paths to search, default is return of ([[exec-paths]])
+  * `:win-exts` - active on Windows only. Searches for `program` with filename extensions specified in `:win-exts` option.
   If `program` already includes an extension from `:win-exts`, it will be searched as-is first.
-
-  When `program` is a relative or absolute path, `:paths` option is not consulted. On Windows, the `:win-exts`
-  variants are still searched. On other OSes, the path for `program` will be returned if executable,
-  else `nil`."
+  Default is `[\"com\" \"exe\" \"bat\" \"cmd\"]`."
   ([program] (which program nil))
   ([program opts]
    (let [exts (if win?
@@ -1132,7 +1182,7 @@
          (if (:all opts) results (first results)))))))
 
 (defn which-all
-  "Returns every `Path` to `program` found in ([[exec-paths]]). See [[which]]."
+  "Returns a vector of every path to `program` found in ([[exec-paths]]). See [[which]]."
   ([program] (which-all program nil))
   ([program opts]
    (which program (assoc opts :all true))))
@@ -1146,10 +1196,10 @@
 ;;;; Modified since
 
 (defn- last-modified-1
-  "Returns max last-modified of regular file `f`. Returns 0 if file does not exist."
-  ^FileTime [f]
-  (if (exists? f)
-    (last-modified-time f)
+  "Returns max last-modified of regular `file`. Returns 0 if file does not exist."
+  ^FileTime [file]
+  (if (exists? file)
+    (last-modified-time file)
     (FileTime/fromMillis 0)))
 
 (defn- max-filetime [filetimes]
@@ -1158,14 +1208,14 @@
           (FileTime/fromMillis 0) filetimes))
 
 (defn- last-modified
-  "Returns max last-modified of f or of all files within f"
-  [f]
-  (if (exists? f)
-    (if (regular-file? f)
-      (last-modified-1 f)
+  "Returns max last-modified of path or of all files within `path`"
+  [path]
+  (if (exists? path)
+    (if (regular-file? path)
+      (last-modified-1 path)
       (max-filetime
-             (map last-modified-1
-                  (filter regular-file? (path-seq f)))))
+       (map last-modified-1
+            (filter regular-file? (path-seq path)))))
     (FileTime/fromMillis 0)))
 
 (defn- expand-file-set
@@ -1175,42 +1225,42 @@
     (filter regular-file? (path-seq file-set))))
 
 (defn modified-since
-  "Returns seq of regular files (non-directories, non-symlinks) from `file-set` that were modified since the `anchor` path.
-  The `anchor` path can be a regular file or directory, in which case
+  "Returns seq of regular files (non-directories, non-symlinks) from `path-set` that were modified since the `anchor-path`.
+  The `anchor-path` can be a regular file or directory, in which case
   the recursive max last modified time stamp is used as the timestamp
-  to compare with.  The `file-set` may be a regular file, directory or
-  collection of files (e.g. returned by [[glob]]). Directories are
+  to compare with.  The `path-set` may be a regular file, directory or
+  collection of paths (e.g. as returned by [[glob]]). Directories are
   searched recursively."
-  [anchor file-set]
-  (let [lm (last-modified anchor)]
-    (map path (filter #(pos? (.compareTo (last-modified-1 %) lm)) (expand-file-set file-set)))))
+  [anchor-path path-set]
+  (let [lm (last-modified anchor-path)]
+    (map path (filter #(pos? (.compareTo (last-modified-1 %) lm)) (expand-file-set path-set)))))
 
 ;;;; End modified since
 
 ;;;; Zip
 
 (defn unzip
-  "Unzips `zip-file` to `dest` directory (default `\".\"`).
+  "Unzips `zip-file` to `target-dir` (default `\".\"`).
 
    Options:
    * `:replace-existing` - `true` / `false`: overwrite existing files
-   * `:extract-fn` - function that decides if the current ZipEntry
-     should be extracted. The function is only called for the file case
-     (not directories) with a map with entries:
-     * `:entry` and the current ZipEntry
-     * `:name` and the name of the ZipEntry (result of calling `getName`)
-     Extraction only occurs if a truthy value is returned (i.e. not
-     nil/false)."
+   * `:extract-fn` - function that decides if the current `ZipEntry`
+     should be extracted. Extraction only occurs if a truthy value is returned (i.e. not nil/false).
+     The function is only called for for files (not directories) with a single map arg:
+     * `:entry` - the current `ZipEntry`
+     * `:name` - the name of the `ZipEntry` (result of calling `getName`)
+
+  See also: [[zip]]."
   ([zip-file] (unzip zip-file "."))
-  ([zip-file dest] (unzip zip-file dest nil))
-  ([zip-file dest {:keys [replace-existing extract-fn]}]
-   (let [output-path (as-path dest)
-         _ (create-dirs dest)
+  ([zip-file target-dir] (unzip zip-file target-dir nil))
+  ([zip-file target-dir {:keys [replace-existing extract-fn]}]
+   (let [output-path (as-path target-dir)
+         _ (create-dirs target-dir)
          cp-opts (->copy-opts replace-existing nil nil nil)]
      (with-open
-       [^InputStream fis
-        (if (instance? InputStream zip-file) zip-file
-            (Files/newInputStream (as-path zip-file) (into-array java.nio.file.OpenOption [])))
+      [^InputStream fis
+       (if (instance? InputStream zip-file) zip-file
+           (Files/newInputStream (as-path zip-file) (into-array java.nio.file.OpenOption [])))
        zis (ZipInputStream. fis)]
        (loop []
          (let [entry (.getNextEntry zis)]
@@ -1231,23 +1281,23 @@
 
 ;; partially borrowed from tools.build
 (defn- add-zip-entry
-  [^ZipOutputStream output-stream ^Path f fpath]
-  (let [dir (directory? f)
-        attrs (Files/readAttributes f BasicFileAttributes
+  [^ZipOutputStream output-stream ^Path path fpath]
+  (let [dir (directory? path)
+        attrs (Files/readAttributes path BasicFileAttributes
                                     (->link-opts []))
         entry (doto (ZipEntry. (str fpath))
                 (.setLastModifiedTime (.lastModifiedTime attrs)))]
     (.putNextEntry output-stream entry)
     (when-not dir
-      (with-open [fis (BufferedInputStream. (FileInputStream. (file f)))]
+      (with-open [fis (BufferedInputStream. (FileInputStream. (file path)))]
         (io/copy fis output-stream)))
 
     (.closeEntry output-stream)))
 
 ;; partially borrowed from tools.build
 (defn- copy-to-zip
-  [^ZipOutputStream jos f path-fn]
-  (let [files (path-seq f)]
+  [^ZipOutputStream jos path path-fn]
+  (let [files (path-seq path)]
     (run! (fn [^Path f]
             (let [dir (directory? f)
                   fpath (str f)
@@ -1261,22 +1311,24 @@
 
 ;; partially borrowed from tools.build
 (defn zip
-  "Zips entry or `entries` into `zip-file`. An entry may be a file or
+  "Zips `path-or-paths` into `zip-file`. A path may be a file or
   directory. Directories are included recursively and their names are
-  preserved in the zip file. Currently only accepts relative entries.
+  preserved in the zip file. Currently only accepts relative paths.
 
   Options:
-  * `:root`: directory which will be elided in zip. E.g.: `(fs/zip [\"src\"] {:root \"src\"})`
-  * `:path-fn`: a single-arg function from file system path to zip entry path.
-  "
-  ([zip-file entries]
-   (zip zip-file entries nil))
-  ([zip-file entries opts]
-   (let [entries (if (or (string? entries)
-                         (instance? File entries)
-                         (instance? Path entries))
-                   [entries]
-                   entries)
+  * `:root` - optional directory to be elided in `zip-file` entries. E.g.: `(fs/zip [\"src\"] {:root \"src\"})`
+  * `:path-fn` - an optional custom path conversion function.
+  A single-arg function called for each file sytem path returning the path to be used for the corresponding zip entry.
+
+  See also: [[unzip]]."
+  ([zip-file path-or-paths]
+   (zip zip-file path-or-paths nil))
+  ([zip-file path-or-paths opts]
+   (let [entries (if (or (string? path-or-paths)
+                         (instance? File path-or-paths)
+                         (instance? Path path-or-paths))
+                   [path-or-paths]
+                   path-or-paths)
          path-fn (or (:path-fn opts)
                      (when-let [root (:root opts)]
                        #(str/replace % (re-pattern (str "^" (java.util.regex.Pattern/quote root) "/")) ""))
@@ -1294,13 +1346,13 @@
 ;;;; GZip
 
 (defn gunzip
-  "Extracts `gz-file` to `dest` dir.
+  "Extracts `gz-file` to `target-dir`.
 
-   If `dest` dir not specified (or `nil`) defaults to `gz-file` dir.
+   If `target-dir` not specified (or `nil`) defaults to `gz-file` dir.
 
-   File is extracted to `dest` dir with `gz-file` [[file-name]] without `.gz` extension.
+   File is extracted to `target-dir` with `gz-file` [[file-name]] without `.gz` extension.
 
-   Creates `dest` dir(s) if necessary.
+   Creates `target-dir` dir(s) if necessary.
    The `gz-file` is not deleted.
 
    Options:
@@ -1308,13 +1360,13 @@
 
    See also: [[gzip]]"
   ([gz-file] (gunzip gz-file nil))
-  ([gz-file dest] (gunzip gz-file dest {}))
-  ([gz-file dest {:keys [replace-existing]}]
-   (let [dest-dir (or dest (parent gz-file) "")
+  ([gz-file target-dir] (gunzip gz-file target-dir {}))
+  ([gz-file target-dir {:keys [replace-existing]}]
+   (let [dest-dir (or target-dir (parent gz-file) "")
          dest-filename (str/replace-first (file-name gz-file) #"\.gz$" "")
          gz-file (as-path gz-file)
          cp-opts (->copy-opts replace-existing nil nil nil)
-         output-file (path dest-dir dest-filename)] 
+         output-file (path dest-dir dest-filename)]
      (with-open
       [fis (Files/newInputStream gz-file (into-array java.nio.file.OpenOption []))
        gzis (GZIPInputStream. fis)]
@@ -1325,14 +1377,14 @@
                    cp-opts)))))
 
 (defn gzip
-  "Gzips `source-file` to `dir/out-file`.
+  "Gzips `source-file` to `:dir`/`:out-file`.
 
   Does not store the `source-file` name in the `.gz` file.
   The `source-file` is not deleted.
 
   Options:
-  * `dir`(s) created if necessary. If not specified, defaults to `source-file` dir.
-  * `out-file` if not specified, defaults to `source-file` [[file-name]] with `.gz` extension.
+  * `:dir`(s) - created if necessary. If not specified, defaults to `source-file` dir.
+  * `:out-file` - if not specified, defaults to `source-file` [[file-name]] with `.gz` extension.
 
   Returns the created gzip file.
 
@@ -1359,14 +1411,16 @@
 ;;;; End gzip
 
 (defmacro with-temp-dir
-  "Evaluates body with binding-name bound to the result of `(create-temp-dir
-  options)`. See [[create-temp-dir]] for valid `options`.
+  "Evaluates body with `temp-dir` bound to the result of `(create-temp-dir
+  opts)`.
 
-  The directory will be removed with [[delete-tree]] on exit from the scope,
-  unless the option `:keep true` is used.
+  By default, the `temp-dir` will be removed with [[delete-tree]] on exit from the scope.
 
+  Options:
+  * see [[delete-tree]]
+  * `:keep` - if `true` does not delete the directory on exit from macro scope. 
+  
   Example:
-
   ```
   (with-temp-dir [d]
     (let [t (path d \"extract\")
@@ -1376,17 +1430,17 @@
   ;; d no longer exists here
   ```
   "
-  {:arglists '[[[binding-name] & body]
-               [[binding-name options] & body]]}
-  [[binding-name options & more] & body]
-  {:pre [(empty? more) (symbol? binding-name)]}
-  `(let [opts# ~options
-         ~binding-name (create-temp-dir opts#)]
+  {:arglists '[[[temp-dir] & body]
+               [[temp-dir opts] & body]]}
+  [[temp-dir opts & more] & body]
+  {:pre [(empty? more) (symbol? temp-dir)]}
+  `(let [opts# ~opts
+         ~temp-dir (create-temp-dir opts#)]
      (try
        ~@body
        (finally
          (when-not (:keep opts#)
-           (delete-tree ~binding-name {:force true}))))))
+           (delete-tree ~temp-dir {:force true}))))))
 
 (def ^:private cached-home-dir
   (delay (path (System/getProperty "user.home"))))
@@ -1395,38 +1449,44 @@
   (delay (parent @cached-home-dir)))
 
 (defn home
-  "With no arguments, returns the current value of the `user.home`
-  system property as a `Path`. If a `user` is passed, returns that user's home
+  "Returns home dir path.
+
+  With no arguments, returns the current value of the `user.home`
+  system property as a path. If a `user` is passed, returns that user's home
   directory as found in the parent of home with no args."
   (^Path [] @cached-home-dir)
   (^Path [user] (if (empty? user) @cached-home-dir
                     (path @cached-users-dir user))))
 
 (defn expand-home
-  "If `f` begins with a tilde (`~`), expand the tilde to the value
-  of the `user.home` system property. If the `f` begins with a
-  tilde immediately followed by some characters, they are assumed to
-  be a username. This is expanded to the path to that user's home
-  directory. This is (naively) assumed to be a directory with the same
-  name as the user relative to the parent of the current value of
-  `user.home`. Returns a `Path`"
-  ^Path [f]
-  (let [p (as-path f)
+  "Returns `path` replacing `~` (tilde) with home dir.
+
+  If `path`:
+  - does not start with `~`, returns `path`.
+  - starts with `~` then [[file-separator]], `~` is replaced with `(home)`.
+  e.g., `~/foo` -> `/home/myuser/foo` 
+  - starts with `~` then some other chars, those other chars are
+  assumed to be a username, then naively expanded to `(home username)`.
+  e.g., `~someuser/foo` -> `/home/someuser/foo`  
+
+  See also: [[home]]"
+  ^Path [path]
+  (let [p (as-path path)
         path-str (str p)]
     (if (.startsWith path-str "~")
       (let [sep (.indexOf path-str File/separator)]
         (if (neg? sep)
           (home (subs path-str 1))
-          (path (home (subs path-str 1 sep)) (subs path-str (inc sep)))))
+          (path* (home (subs path-str 1 sep)) (subs path-str (inc sep)))))
       p)))
 
 (defn windows?
-  "Returns true if OS is Windows."
+  "Returns `true` if OS is Windows."
   []
   win?)
 
 (defn cwd
-  "Returns current working directory as `Path`"
+  "Returns current working directory path."
   []
   (as-path (System/getProperty "user.dir")))
 
@@ -1452,13 +1512,13 @@
                              acc)) [] opts)))
 
 (defn write-bytes
-  "Writes `bytes` to `path` via [Files/write](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#write(java.nio.file.Path,byte%5B%5D,java.nio.file.OpenOption...)).
+  "Writes `bytes` to `file` via [Files/write](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#write(java.nio.file.Path,byte%5B%5D,java.nio.file.OpenOption...)).
 
   Options:
-  * `:create` (default `true`)
-  * `:truncate-existing` (default `true`)
-  * `:write` (default `true`)
-  * `:append` (default `false`)
+  * `:create` - (default `true`)
+  * `:truncate-existing` - (default `true`)
+  * `:write` - (default `true`)
+  * `:append` - (default `false`)
   * or any `java.nio.file.StandardOption`.
 
   Examples:
@@ -1467,21 +1527,21 @@
   (fs/write-bytes f (.getBytes (String. \"foo\"))) ;; overwrites + truncates or creates new file
   (fs/write-bytes f (.getBytes (String. \"foo\")) {:append true})
   ```"
-  ([path bytes] (write-bytes path bytes nil))
-  ([path bytes {:keys [append
+  ([file bytes] (write-bytes file bytes nil))
+  ([file bytes {:keys [append
                        ;; default when no options are given:
                        create
                        truncate-existing
                        write] :as opts}]
-   (let [path (as-path path)
+   (let [path (as-path file)
          opts (->open-options opts)]
      (java.nio.file.Files/write path ^bytes bytes opts))))
 
 (defn write-lines
-  "Writes `lines`, a seqable of strings to `path` via [Files/write](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#write(java.nio.file.Path,java.lang.Iterable,java.nio.charset.Charset,java.nio.file.OpenOption...)).
+  "Writes `lines`, a seqable of strings, to `file` via [Files/write](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#write(java.nio.file.Path,java.lang.Iterable,java.nio.charset.Charset,java.nio.file.OpenOption...)).
 
   Options:
-  * `:charset` (default `\"utf-8\"`)
+  * `:charset` - (default `\"utf-8\"`)
 
   Open options:
   * `:create` (default `true`)
@@ -1489,38 +1549,38 @@
   * `:write` (default `true`)
   * `:append` (default `false`)
   * or any `java.nio.file.StandardOption`."
-  ([path lines] (write-lines path lines nil))
-  ([path lines {:keys [charset]
+  ([file lines] (write-lines file lines nil))
+  ([file lines {:keys [charset]
                 :or {charset "utf-8"}
                 :as opts}]
-   (java.nio.file.Files/write (as-path path)
+   (java.nio.file.Files/write (as-path file)
                               lines
                               (->charset charset)
                               (->open-options (dissoc opts :charset)))))
 
 (defn update-file
-  "Updates the contents of text file `path` using `f` applied to old contents and `xs`.
+  "Updates the contents of text `file` with result of applying function `f` with old contents and args `xs`.
   Returns the new contents.
 
   Options:
   * `:charset` - charset of file, default to \"utf-8\""
-  {:arglists '([path f & xs] [path opts f & xs])}
-  ([path f & xs]
+  {:arglists '([file f & xs] [file opts f & xs])}
+  ([file f & xs]
    (let [[opts f xs] (if (map? f)
                        [f (first xs) (rest xs)]
                        [nil f xs])
          {:keys [charset]
           :or {charset "utf-8"}} opts
          opts [:encoding charset]
-         old-val (apply slurp (as-file path) opts)
+         old-val (apply slurp (as-file file) opts)
          new-val (apply f old-val xs)]
-     (apply spit (as-file path) new-val opts)
+     (apply spit (as-file file) new-val opts)
      new-val)))
 
 (defn unixify
-  "Returns path as string with Unix-style file separators (`/`)."
-  [f]
-  (let [s (str f)]
+  "Returns `path` as string with Unix-style file separators (`/`)."
+  [path]
+  (let [s (str path)]
     (if win?
       (.replace s "\\" "/")
       s)))
@@ -1546,40 +1606,40 @@
      default-path)))
 
 (defn xdg-config-home
-  "Path representing the base directory relative to which user-specific configuration files should be stored as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+  "Returns path to user-specific configuration files as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 
-  Returns path based on the value of env-var `XDG_CONFIG_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) \".config\")`.
-  When provided, appends `app` to the path."
+  Uses env-var `XDG_CONFIG_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) \".config\")`.
+  When provided, appends `app` to the returned path."
   ([] (xdg-config-home nil))
   ([app]
    (cond-> (xdg-home-for :config)
      (seq app) (path app))))
 
 (defn xdg-cache-home
-  "Path representing the base directory relative to which user-specific non-essential data files should be stored as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+  "Returns path to user-specific non-essential data as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 
-  Returns path based on the value of env-var `XDG_CACHE_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) \".cache\")`.
-  When provided, appends `app` to the path."
+  Uses env-var `XDG_CACHE_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) \".cache\")`.
+  When provided, appends `app` to the returned path."
   ([] (xdg-cache-home nil))
   ([app]
    (cond-> (xdg-home-for :cache)
      (seq app) (path app))))
 
 (defn xdg-data-home
-  "Path representing the base directory relative to which user-specific data files should be stored as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+  "Returns path to user-specific data files as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 
-  Returns path based on the value of env-var `XDG_DATA_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) \".local\" \"share\")`.
-  When provided, appends `app` to the path."
+  Uses env-var `XDG_DATA_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) \".local\" \"share\")`.
+  When provided, appends `app` to the returned path."
   ([] (xdg-data-home nil))
   ([app]
    (cond-> (xdg-home-for :data)
      (seq app) (path app))))
 
 (defn xdg-state-home
-  "Path representing the base directory relative to which user-specific state files should be stored as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+  "Returns path to user-specific state files as described in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
 
-  Returns path based on the value of env-var `XDG_STATE_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) \".local\" \"state\")`.
-  When provided, appends `app` to the path."
+  Uses env-var `XDG_STATE_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) \".local\" \"state\")`.
+  When provided, appends `app` to the returned path."
   ([] (xdg-state-home nil))
   ([app]
    (cond-> (xdg-home-for :state)

--- a/src/babashka/fs.cljc
+++ b/src/babashka/fs.cljc
@@ -49,7 +49,7 @@
   (System/getenv k))
 
 (defn path
-  "Returns `path`(s) coerced to a `Path`, combining multiple paths into one.
+  "Coerces `path`(s) into a `Path`, combining multiple paths into one.
   Multiple-arg versions treat the first argument as parent and subsequent
   args as children relative to the parent."
   (^Path [path]
@@ -66,7 +66,7 @@
 (def ^:private path* "synonym to avoid path arg-name to path fn shadowing conflicts" path)
 
 (defn file
-  "Returns `path`(s) coerced to a `File`, combining multiple paths into one.
+  "Coerces `path`(s) into a `File`, combining multiple paths into one.
   Multiple-arg versions treat the first argument as parent and subsequent args
   as children relative to the parent."
   (^File [path] (as-file path))
@@ -81,7 +81,7 @@
                 (conj LinkOption/NOFOLLOW_LINKS))))
 
 (defn real-path
-  "Returns real path for `path` via [Path#toRealPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toRealPath(java.nio.file.LinkOption...)).
+  "Converts `path` into real `Path` via [Path#toRealPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toRealPath(java.nio.file.LinkOption...)).
 
   Options:
   * [`:nofollow-links`](/README.md#nofollow-links)"
@@ -177,7 +177,7 @@
   (seq (as-path path)))
 
 (defn absolutize
-  "Returns absolute path for `path` via [Path#toAbsolutePath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toAbsolutePath())."
+  "Converts `path` into an absolute `Path` via [Path#toAbsolutePath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#toAbsolutePath())."
   [path] (.toAbsolutePath (as-path path)))
 
 (defn relativize
@@ -190,12 +190,12 @@
   (.relativize (as-path base-path) (as-path other-path)))
 
 (defn normalize
-  "Returns normalized path for `path` via [Path#normalize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#normalize())."
+  "Returns normalized `Path` for `path` via [Path#normalize](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#normalize())."
   [path]
   (.normalize (as-path path)))
 
 (defn canonicalize
-  "Returns canonical path for `path` via [File#getCanonicalPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getCanonicalPath()).
+  "Returns the canonical `Path` for `path` via [File#getCanonicalPath](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/File.html#getCanonicalPath()).
 
   Options:
   * [`:nofollow-links`](/README.md#nofollow-links) - when set, falls back on [[absolutize]] + [[normalize]].
@@ -298,7 +298,7 @@
    (defn list-dir
      "Returns a vector of all paths in `dir`. For descending into subdirectories use [[glob]].
 
-     - `glob-or-accept` - a [[glob]] string such as \"*.edn\" or a `(fn accept [^java.nio.file.Path p]) -> truthy`"
+     - `glob-or-accept` - a [[glob]] string such as `\"*.edn\"` or a `(fn accept [^java.nio.file.Path p]) -> truthy`"
      ([dir]
       (with-open [stream (directory-stream dir)]
         (vec stream)))
@@ -353,12 +353,12 @@
   `false`, i.e. skip hidden files and folders.
   * [`:follow-links`](/README.md#follow-links) - follow symlinks. Defaults to false.
   * `:recursive`
-    * `true` - `pattern` is matched against all descendant files and directories under `root`
-    * `false` (default) - `pattern` is matched only against immediate children under `root`
+    * `true` - `pattern` is matched against all descendant files and directories under `root-dir`
+    * `false` (default) - `pattern` is matched only against immediate children under `root-dir`
   * `:max-depth` - max depth to descend into directory structure, when
   matching recursively. Defaults to `Integer/MAX_VALUE`.
 
-  Examples: 
+  Examples:
   - `(fs/match \".\" \"regex:.*\\\\.clj\" {:recursive true})`
 
   See also: [[glob]]"
@@ -419,7 +419,7 @@
 (defn glob
   "Returns a vector of paths matching glob `pattern` (on path and filename) relative to `root-dir`.
   Patterns containing `**` or `/` will cause a recursive walk under
-  `root-dir`, unless overriden with `:recursive false`. Similarly, `:hidden` will be automaticaly enabled 
+  `root-dir`, unless overriden with `:recursive false`. Similarly, `:hidden` will be automatically enabled
   when `pattern` starts with a dot.
   Glob interpretation is done using the rules described in
   [FileSystem#getPathMatcher](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/FileSystem.html#getPathMatcher(java.lang.String))
@@ -430,8 +430,8 @@
   not hidden, unless their hidden attribute is set.
   * [`:follow-links`](/README.md#follow-links) - follow symlinks. Defaults to `false`.
   * `:recursive` - implied `true` when `pattern` contains `**` or `/`; otherwise, defaults to `false`.
-    * `true` - `pattern` is matched against all descendant files and directories under `root`
-    * `false` - `pattern` is matched only against immediate children under `root`
+    * `true` - `pattern` is matched against all descendant files and directories under `root-dir`
+    * `false` - `pattern` is matched only against immediate children under `root-dir`
   * `:max-depth` - max depth to descend into directory structure, when
   recursing. Defaults to `Integer/MAX_VALUE`.
 
@@ -468,7 +468,9 @@
   Options:
   * `:replace-existing`
   * `:copy-attributes`
-  * [`:nofollow-links`](/README.md#nofollow-links) - used to determine to copy symbolic link itself or not."
+  * [`:nofollow-links`](/README.md#nofollow-links) - used to determine to copy symbolic link itself or not.
+
+  Returns `target-path`."
   ([source-file target-path] (copy source-file target-path nil))
   ([source-file target-path {:keys [replace-existing
                                     copy-attributes
@@ -484,18 +486,18 @@
        (Files/copy (as-path source-file) dest copy-options)))))
 
 (defn posix->str
-  "Returns permissions string, like `\"rwx------\"`, for a set of `PosixFilePermission` `p`.
+  "Converts a set of `PosixFilePermission` `p` to a string, like `\"rwx------\"`.
 
-  See also [[str->posix]]"
+  See also: [[str->posix]]"
   [p]
   (PosixFilePermissions/toString p))
 
 (defn str->posix
-  "Returns a set of `PosixFilePermission` for permissions string `s`.
+  "Converts a string `s` to a set of `PosixFilePermission`.
 
   `s` is a string like `\"rwx------\"`.
 
-  See also [[posix->str]]"
+  See also: [[posix->str]]"
   [s]
   (PosixFilePermissions/fromString s))
 
@@ -521,8 +523,10 @@
     (into-array FileAttribute attrs)))
 
 (defn create-dir
-  "Returns new `dir` created via [Files/createDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectory(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+  "Creates `dir` via [Files/createDirectory](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectory(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
   Does not create parents.
+
+  Returns `dir`.
 
   Options:
   * `:posix-file-permissions` - string format for unix-like system permissions for `dir`, as described in [[str->posix]].
@@ -534,10 +538,12 @@
      (Files/createDirectory (as-path dir) attrs))))
 
 (defn create-dirs
-  "Returns `dir` after creating directories for `dir` via [Files/createDirectories](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectories(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+  "Creates `dir` via [Files/createDirectories](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createDirectories(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
   Also creates parents if needed.
   Does not throw an exception if the dirs exist already. Similar to `mkdir -p` shell command.
-  
+
+  Returns `dir`.
+
   Options:
   * `:posix-file-permissions` - string format for unix-like system permissions for `dir`, as described in [[str->posix]].
   Affected by [umask](/README.md#umask)."
@@ -557,7 +563,7 @@
   (Files/setPosixFilePermissions (as-path path) (->posix-file-permissions posix-file-permissions)))
 
 (defn posix-file-permissions
-  "Returns a set of `PosixFilePermissions` for `path` via [Files/getPosixFilePermissions](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getPosixFilePermissions(java.nio.file.Path,java.nio.file.LinkOption...)).
+  "Returns a set of `PosixFilePermission` for `path` via [Files/getPosixFilePermissions](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getPosixFilePermissions(java.nio.file.Path,java.nio.file.LinkOption...)).
   Use [[posix->str]] to convert to a string.
 
   Options:
@@ -594,7 +600,7 @@
 
 (defn copy-tree
   "Copies entire file tree from `source-dir` to `target-dir`. Creates `target-dir` if needed.
- 
+
   Options:
   * same as [[copy]]
   * `:posix-file-permissions` - string format unix-like system permissions passed to [[create-dirs]] when creating `target-dir`."
@@ -739,7 +745,9 @@
         attrs)))))
 
 (defn create-sym-link
-  "Returns new symbolic `link` to `target-path` created via [Files/createSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createSymbolicLink(java.nio.file.Path,java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+  "Creates a symbolic `link` to `target-path` via [Files/createSymbolicLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createSymbolicLink(java.nio.file.Path,java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+
+  Returns `link`.
 
   As of this writing, JDKs do not recognize empty-string `target-path` `\"\"` as the cwd.
   Consider instead using a `target-path` of `\".\"` to link to the cwd."
@@ -750,7 +758,9 @@
    (make-array FileAttribute 0)))
 
 (defn create-link
-  "Returns a new hard `link` (directory entry) for an `existing-file` created via [Files/createLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createLink(java.nio.file.Path,java.nio.file.Path))."
+  "Creates a new hard `link` (directory entry) for an `existing-file` via [Files/createLink](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createLink(java.nio.file.Path,java.nio.file.Path)).
+
+  Returns `link`."
   [link existing-file]
   (Files/createLink
    (as-path link)
@@ -808,7 +818,9 @@
                                         :continue)}))))
 
 (defn create-file
-  "Returns new empty `file` created via [Files/createFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createFile(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+  "Creates empty `file` via [Files/createFile](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#createFile(java.nio.file.Path,java.nio.file.attribute.FileAttribute...)).
+
+  Returns `file`.
 
   Options:
   * `:posix-file-permissions` - string format for unix-like system permissions for `file`, as described in [[str->posix]].
@@ -824,7 +836,7 @@
   If `target-path` is a directory, moves `source-path` under `target-path`.
   Never follows symbolic links.
 
-  Returns `target-path` path.
+  Returns `target-path`.
 
   Options:
   * `replace-existing` - overwrite existing `target-path`, default `false`
@@ -844,7 +856,7 @@
                    (->copy-opts replace-existing false atomic-move nofollow-links))))))
 
 (defn parent
-  "Returns parent path of `path` via [Paths/getParent](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#getParent()).
+  "Returns parent path of `path` via [Path#getParent](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Path.html#getParent()).
   Akin to `dirname` in bash."
   [path]
   (.getParent (as-path path)))
@@ -878,10 +890,10 @@
     charset))
 
 (defn read-all-lines
-  "Return contents of `file` as a vector of lines via [Files/readAllLines](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllLines(java.nio.file.Path,java.nio.charset.Charset)).
+  "Returns contents of `file` as a vector of lines via [Files/readAllLines](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#readAllLines(java.nio.file.Path,java.nio.charset.Charset)).
 
   Options:
-  - `:charset` - defaults to `\"utf-8\"`"
+  * `:charset` - defaults to `\"utf-8\"`"
   ([file]
    (vec (Files/readAllLines (as-path file))))
   ([file {:keys [charset]
@@ -893,7 +905,7 @@
 ;;;; Attributes, from github.com/corasaurus-hex/fs
 
 (defn get-attribute
-  "Returns `attribute` for `path` via [Files/getAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getAttribute(java.nio.file.Path,java.lang.String,java.nio.file.LinkOption...)).
+  "Returns value of `attribute` for `path` via [Files/getAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#getAttribute(java.nio.file.Path,java.lang.String,java.nio.file.LinkOption...)).
 
   Options:
   * [`:nofollow-links`](/README.md#nofollow-links)"
@@ -944,7 +956,7 @@
         (keyize (or key-fn keyword)))))
 
 (defn set-attribute
-  "Sets `attribute` for `path` to `value` via [Files/setAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#setAttribute(java.nio.file.Path,java.lang.String,java.lang.Object,java.nio.file.LinkOption...))"
+  "Sets `attribute` for `path` to `value` via [Files/setAttribute](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/Files.html#setAttribute(java.nio.file.Path,java.lang.String,java.lang.Object,java.nio.file.LinkOption...))."
   ([path attribute value]
    (set-attribute path attribute value nil))
   ([path attribute value {:keys [:nofollow-links]}]
@@ -954,26 +966,25 @@
                        (->link-opts nofollow-links))))
 
 (defn file-time->instant
-  "Returns [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html) `ft`
-  as [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html)."
+  "Converts `ft` [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)
+  to an [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html)."
   [^FileTime ft]
   (.toInstant ft))
 
 (defn instant->file-time
-  "Returns [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html) `instant`
-  as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)."
+  "Converts `instant` [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html)
+  to a [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)."
   [instant]
   (FileTime/from instant))
 
 (defn file-time->millis
-  "Returns [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html) `ft`
-  as epoch milliseconds (long)."
+  "Converts `ft` [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)
+  to epoch milliseconds (long)."
   [^FileTime ft]
   (.toMillis ft))
 
 (defn millis->file-time
-  "Returns epoch milliseconds (long)
-  as [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)"
+  "Converts epoch milliseconds (long) to a [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html)."
   [millis]
   (FileTime/fromMillis millis))
 
@@ -993,7 +1004,7 @@
    (get-attribute path "basic:lastModifiedTime" opts)))
 
 (defn set-last-modified-time
-  "Sets last modified `time` of `path`. 
+  "Sets last modified `time` of `path`.
   `time` can be `epoch milliseconds`,
   [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html),
   or [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html).
@@ -1019,7 +1030,7 @@
   "Sets creation `time` of `path`.
   `time` can be `epoch milliseconds`,
   [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/attribute/FileTime.html),
-  or [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html) .
+  or [Instant](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Instant.html).
 
   Options:
   * [`:nofollow-links`](/README.md#nofollow-links)
@@ -1033,7 +1044,7 @@
    (set-attribute path "basic:creationTime" (->file-time time) opts)))
 
 (defn touch
-  "Update last modified time of `path` to `:time`, creating `path` as a file if it does not exist.
+  "Updates last modified time of `path` to `:time`, creating `path` as a file if it does not exist.
 
   If `path` is deleted by some other process/thread before `:time` is set,
   a `NoSuchFileException` will be thrown. Callers can, if their use case requires it,
@@ -1068,12 +1079,12 @@
   (mapcat #(list-dir % glob-or-accept) dirs))
 
 (defn split-ext
-  "Returns `path` split on extension.
+  "Splits `path` on extension. Returns `[name ext]`.
   Leading directories in `path` are not processed.
 
   Options:
-  * `:ext` - split on specified extension (do not include a leading dot) 
-  
+  * `:ext` - split on specified extension (do not include a leading dot)
+
   Examples:
   - `(fs/split-ext \"foo.bar.baz\")` => `[\"foo.bar\" \"baz\"]`
   - `(fs/split-ext \"foo.bar.baz\" {:ext \"bar.baz\"})`  => `[\"foo\" \"bar.baz\"]`
@@ -1088,14 +1099,14 @@
                    (subs file-name last-dot)))]
        (if (and ext
                 (str/ends-with? path-str ext)
-                (not= path-str ext))
+                (not= file-name ext))
          (let [loc (str/last-index-of path-str ext)]
            [(subs path-str 0 loc)
             (subs path-str (inc loc))])
          [path-str nil])))))
 
 (defn strip-ext
-  "Returns `path` with extension stripped via [[split-ext]]."
+  "Strips extension from `path` via [[split-ext]]."
   ([path]
    (strip-ext path nil))
   ([path {:keys [ext] :as opts}]
@@ -1107,8 +1118,7 @@
   (-> path split-ext last))
 
 (defn split-paths
-  "Returns a vector of paths from paths in `joined-paths` string.
-  `joined-paths` is split on OS-specific [[path-separator]].
+  "Splits `joined-paths` string into a vector of paths by OS-specific [[path-separator]].
   On UNIX systems, the separator is `:`, on Microsoft Windows systems it is `;`."
   [^String joined-paths]
   (mapv path (.split joined-paths path-separator)))
@@ -1208,7 +1218,7 @@
           (FileTime/fromMillis 0) filetimes))
 
 (defn- last-modified
-  "Returns max last-modified of path or of all files within `path`"
+  "Returns max last-modified of `path` or of all files within `path`."
   [path]
   (if (exists? path)
     (if (regular-file? path)
@@ -1246,7 +1256,7 @@
    * `:replace-existing` - `true` / `false`: overwrite existing files
    * `:extract-fn` - function that decides if the current `ZipEntry`
      should be extracted. Extraction only occurs if a truthy value is returned (i.e. not nil/false).
-     The function is only called for for files (not directories) with a single map arg:
+     The function is only called for files (not directories) with a single map arg:
      * `:entry` - the current `ZipEntry`
      * `:name` - the name of the `ZipEntry` (result of calling `getName`)
 
@@ -1318,7 +1328,7 @@
   Options:
   * `:root` - optional directory to be elided in `zip-file` entries. E.g.: `(fs/zip [\"src\"] {:root \"src\"})`
   * `:path-fn` - an optional custom path conversion function.
-  A single-arg function called for each file sytem path returning the path to be used for the corresponding zip entry.
+  A single-arg function called for each file system path returning the path to be used for the corresponding zip entry.
 
   See also: [[unzip]]."
   ([zip-file path-or-paths]
@@ -1366,7 +1376,7 @@
          dest-filename (str/replace-first (file-name gz-file) #"\.gz$" "")
          gz-file (as-path gz-file)
          cp-opts (->copy-opts replace-existing nil nil nil)
-         output-file (path dest-dir dest-filename)]
+         output-file (path dest-dir dest-filename)] 
      (with-open
       [fis (Files/newInputStream gz-file (into-array java.nio.file.OpenOption []))
        gzis (GZIPInputStream. fis)]
@@ -1411,15 +1421,14 @@
 ;;;; End gzip
 
 (defmacro with-temp-dir
-  "Evaluates body with `temp-dir` bound to the result of `(create-temp-dir
-  opts)`.
+  "Evaluates body with `temp-dir` bound to the result of `(create-temp-dir opts)`.
 
   By default, the `temp-dir` will be removed with [[delete-tree]] on exit from the scope.
 
   Options:
-  * see [[delete-tree]]
-  * `:keep` - if `true` does not delete the directory on exit from macro scope. 
-  
+  * see [[create-temp-dir]] for options that control directory creation
+  * `:keep` - if `true` does not delete the directory on exit from macro scope.
+
   Example:
   ```
   (with-temp-dir [d]
@@ -1452,7 +1461,7 @@
   "Returns home dir path.
 
   With no arguments, returns the current value of the `user.home`
-  system property as a path. If a `user` is passed, returns that user's home
+  system property. If a `user` is passed, returns that user's home
   directory as found in the parent of home with no args."
   (^Path [] @cached-home-dir)
   (^Path [user] (if (empty? user) @cached-home-dir
@@ -1464,10 +1473,10 @@
   If `path`:
   - does not start with `~`, returns `path`.
   - starts with `~` then [[file-separator]], `~` is replaced with `(home)`.
-  e.g., `~/foo` -> `/home/myuser/foo` 
+  e.g., `~/foo` -> `/home/myuser/foo`
   - starts with `~` then some other chars, those other chars are
   assumed to be a username, then naively expanded to `(home username)`.
-  e.g., `~someuser/foo` -> `/home/someuser/foo`  
+  e.g., `~someuser/foo` -> `/home/someuser/foo`
 
   See also: [[home]]"
   ^Path [path]
@@ -1544,10 +1553,10 @@
   * `:charset` - (default `\"utf-8\"`)
 
   Open options:
-  * `:create` (default `true`)
-  * `:truncate-existing` (default `true`)
-  * `:write` (default `true`)
-  * `:append` (default `false`)
+  * `:create` - (default `true`)
+  * `:truncate-existing` - (default `true`)
+  * `:write` - (default `true`)
+  * `:append` - (default `false`)
   * or any `java.nio.file.StandardOption`."
   ([file lines] (write-lines file lines nil))
   ([file lines {:keys [charset]

--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -398,6 +398,10 @@
 ;;
 ;; create-file
 ;;
+
+(deftest create-file-test
+  (is (= "new-file" (str (fs/create-file "new-file")))))
+
 (deftest create-file-empty-string-test
   ;; NOTE:
   ;; - JDK25 linux throws:  java.nio.file.FileAlreadyExistsException
@@ -441,7 +445,7 @@
   (if (not= :mac (util/os))
     ;; linux/windows bug? inconsistent: if "" is cwd, should be equivalent to (fs/create-sym-link "symlink1" ".") but throws:
     (is (thrown? Exception  (fs/create-sym-link "symlink1" "")))
-    (do (fs/create-sym-link "symlink1" "")
+    (do (is (= "symlink1" (str (fs/create-sym-link "symlink1" ""))))
         ;; link is created
         (is (= true (fs/sym-link? "symlink1")))
         ;; but does not map to cwd

--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -776,6 +776,8 @@
   (is (= "clj" (fs/extension "file-name.clj")))
   (is (= "template" (fs/extension "file-name.html.template")))
   (is (nil? (fs/extension ".dotfile")))
+  (is (nil? (fs/extension "foo/.dotfile")))
+  (is (nil? (fs/extension "/home/.zshrc")))
   (is (nil? (fs/extension "bin/something"))))
 
 (deftest extension-empty-string-test
@@ -2045,6 +2047,8 @@
     (is (= ["/path/to/file" "ext"] (fs/split-ext "/path/to/file.ext")))
     (is (= ["some/path/hi.tar" "gz"] (fs/split-ext "some/path/hi.tar.gz")))
     (is (= [".dotfile" nil] (fs/split-ext ".dotfile")))
+    (is (= ["foo/.dotfile" nil] (fs/split-ext "foo/.dotfile")))
+    (is (= ["/home/.zshrc" nil] (fs/split-ext "/home/.zshrc")))
     (is (= ["name" nil] (fs/split-ext "name"))))
 
   (testing "coerces paths and files"


### PR DESCRIPTION
Step 1 for #197: Initial docstring & arg names review.

Args lists naming review, now using:
- `path` (or `-path` suffix) for a file or dir (which might be a string, Path, or File)
- `dir` or `-dir` suffix means always directory
- `file` or `-file` suffix means always a file (not to be confused with File)
- `target` (was using `dest` sometimes)
- `source` (was using `src` sometimes)

Note: I added private `babashka.fs/path*` to be used when there would otherwise be a collision between `path` arg and `path` fn.

Consistent language for docstrings.
I.e., now consistently "Returns ... "

Consistently describe `opts` under Options:, and as keywords.

Get much less wordy for xdg-* and reworded some other fns.

As requested, now vague on return values.
We now only explicitly state `Path` for fs/path, and `File` for fs/file.

Vaguely documented return types of fns that are simple pass-thrus to JDK. Tests mostly already covered these, but filled missing gaps.

Added "Coercions and Returns" and "Argument Naming Conventions" sections to README.

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/babashka/fs/blob/master/CHANGELOG.md) file with a description of the addressed issue.
