### PR TITLE
api returns: define returns for zip & unzip

### DIFF
--- a/API.md
+++ b/API.md
@@ -342,7 +342,7 @@ See also: [`set-creation-time`](#babashka.fs/set-creation-time), [`last-modified
 Function.
 
 Returns current working directory path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1504-L1507">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1511-L1514">Source</a></sub></p>
 
 ## <a name="babashka.fs/delete">`delete`</a>
 ``` clojure
@@ -464,7 +464,7 @@ assumed to be a username, then naively expanded to `(home username)`.
 e.g., `~someuser/foo` -> `/home/someuser/foo`
 
 See also: [`home`](#babashka.fs/home)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1477-L1497">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1484-L1504">Source</a></sub></p>
 
 ## <a name="babashka.fs/extension">`extension`</a>
 ``` clojure
@@ -594,7 +594,7 @@ Options:
 * `:replace-existing` - when `true` overwrites existing file
 
 See also: [`gzip`](#babashka.fs/gzip)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1365-L1394">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1372-L1401">Source</a></sub></p>
 
 ## <a name="babashka.fs/gzip">`gzip`</a>
 ``` clojure
@@ -615,7 +615,7 @@ Options:
 Returns the created gzip file.
 
 See also: [`gunzip`](#babashka.fs/gunzip)
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1396-L1426">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1403-L1433">Source</a></sub></p>
 
 ## <a name="babashka.fs/hidden?">`hidden?`</a>
 ``` clojure
@@ -641,7 +641,7 @@ Returns home dir path.
 With no arguments, returns the current value of the `user.home`
 system property. If a `user` is passed, returns that user's home
 directory as found in the parent of home with no args.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1467-L1475">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1474-L1482">Source</a></sub></p>
 
 ## <a name="babashka.fs/instant->file-time">`instant->file-time`</a>
 ``` clojure
@@ -1153,7 +1153,7 @@ or [FileTime](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/
 Function.
 
 Returns `path` as string with Unix-style file separators (`/`).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1596-L1602">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1603-L1609">Source</a></sub></p>
 
 ## <a name="babashka.fs/unzip">`unzip`</a>
 ``` clojure
@@ -1165,7 +1165,9 @@ Function.
 
 Unzips `zip-file` to `target-dir` (default `"."`).
 
- Options:
+Returns `target-dir`.
+
+Options:
  * `:replace-existing` - `true` / `false`: overwrite existing files
  * `:extract-fn` - function that decides if the current [ZipEntry](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/zip/ZipEntry.html)
    should be extracted. Extraction only occurs if a truthy value is returned (i.e. not nil/false).
@@ -1174,7 +1176,7 @@ Unzips `zip-file` to `target-dir` (default `"."`).
    * `:name` - the name of the `ZipEntry` (result of calling `getName`)
 
 See also: [`zip`](#babashka.fs/zip).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1259-L1297">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1259-L1300">Source</a></sub></p>
 
 ## <a name="babashka.fs/update-file">`update-file`</a>
 ``` clojure
@@ -1188,7 +1190,7 @@ Returns the new contents.
 
 Options:
 * `:charset` - charset of file, default to "utf-8"
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1577-L1594">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1584-L1601">Source</a></sub></p>
 
 ## <a name="babashka.fs/walk-file-tree">`walk-file-tree`</a>
 ``` clojure
@@ -1251,7 +1253,7 @@ Returns a vector of every path to `program` found in ([`exec-paths`](#babashka.f
 Function.
 
 Returns `true` if OS is Windows.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1499-L1502">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1506-L1509">Source</a></sub></p>
 
 ## <a name="babashka.fs/with-temp-dir">`with-temp-dir`</a>
 ``` clojure
@@ -1278,7 +1280,7 @@ Example:
 ;; d no longer exists here
 ```
   
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1430-L1459">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1437-L1466">Source</a></sub></p>
 
 ## <a name="babashka.fs/writable?">`writable?`</a>
 ``` clojure
@@ -1311,7 +1313,7 @@ Examples:
 (fs/write-bytes f (.getBytes (String. "foo"))) ;; overwrites + truncates or creates new file
 (fs/write-bytes f (.getBytes (String. "foo")) {:append true})
 ```
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1530-L1554">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1537-L1561">Source</a></sub></p>
 
 ## <a name="babashka.fs/write-lines">`write-lines`</a>
 ``` clojure
@@ -1331,7 +1333,7 @@ Open options:
 * `:write` - (default `true`)
 * `:append` - (default `false`)
 * or any `java.nio.file.StandardOption`.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1556-L1575">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1563-L1582">Source</a></sub></p>
 
 ## <a name="babashka.fs/xdg-cache-home">`xdg-cache-home`</a>
 ``` clojure
@@ -1344,7 +1346,7 @@ Returns path to user-specific non-essential data as described in the [XDG Base D
 
 Uses env-var `XDG_CACHE_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) ".cache")`.
 When provided, appends `app` to the returned path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1634-L1642">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1641-L1649">Source</a></sub></p>
 
 ## <a name="babashka.fs/xdg-config-home">`xdg-config-home`</a>
 ``` clojure
@@ -1357,7 +1359,7 @@ Returns path to user-specific configuration files as described in the [XDG Base 
 
 Uses env-var `XDG_CONFIG_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) ".config")`.
 When provided, appends `app` to the returned path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1624-L1632">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1631-L1639">Source</a></sub></p>
 
 ## <a name="babashka.fs/xdg-data-home">`xdg-data-home`</a>
 ``` clojure
@@ -1370,7 +1372,7 @@ Returns path to user-specific data files as described in the [XDG Base Directory
 
 Uses env-var `XDG_DATA_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) ".local" "share")`.
 When provided, appends `app` to the returned path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1644-L1652">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1651-L1659">Source</a></sub></p>
 
 ## <a name="babashka.fs/xdg-state-home">`xdg-state-home`</a>
 ``` clojure
@@ -1383,7 +1385,7 @@ Returns path to user-specific state files as described in the [XDG Base Director
 
 Uses env-var `XDG_STATE_HOME` (if set and representing an absolute path), else `(fs/path (fs/home) ".local" "state")`.
 When provided, appends `app` to the returned path.
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1654-L1662">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1661-L1669">Source</a></sub></p>
 
 ## <a name="babashka.fs/zip">`zip`</a>
 ``` clojure
@@ -1396,10 +1398,12 @@ Zips `path-or-paths` into `zip-file`. A path may be a file or
 directory. Directories are included recursively and their names are
 preserved in the zip file. Currently only accepts relative paths.
 
+Returns created `zip-file`.
+
 Options:
 * `:root` - optional directory to be elided in `zip-file` entries. E.g.: `(fs/zip ["src"] {:root "src"})`
 * `:path-fn` - an optional custom path conversion function.
 A single-arg function called for each file system path returning the path to be used for the corresponding zip entry.
 
 See also: [`unzip`](#babashka.fs/unzip).
-<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1330-L1359">Source</a></sub></p>
+<p><sub><a href="https://github.com/babashka/fs/blob/master/src/babashka/fs.cljc#L1333-L1366">Source</a></sub></p>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Babashka [fs](https://github.com/babashka/fs): file system utility library for C
   - `copy` returns copied target file (fixed for case when `source` is input stream)
   - `copy-tree` now explicitly returns `target-dir` (previously undefined)
   - `delete-tree` existing return value now documented (previously undefined)
+  - `unzip` now explicitly returns `target-dir` (previously undefined)
+  - `zip` now explicitly returns created `zip-file` (previously undefined)
 
 ## 0.5.33 (2026-04-20)
 

--- a/src/babashka/fs.cljc
+++ b/src/babashka/fs.cljc
@@ -1259,7 +1259,9 @@
 (defn unzip
   "Unzips `zip-file` to `target-dir` (default `\".\"`).
 
-   Options:
+  Returns `target-dir`.
+
+  Options:
    * `:replace-existing` - `true` / `false`: overwrite existing files
    * `:extract-fn` - function that decides if the current [ZipEntry](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/zip/ZipEntry.html)
      should be extracted. Extraction only occurs if a truthy value is returned (i.e. not nil/false).
@@ -1294,7 +1296,8 @@
                    (Files/copy ^java.io.InputStream zis
                                new-path
                                cp-opts))))
-             (recur))))))))
+             (recur)))))
+     output-path)))
 
 ;; partially borrowed from tools.build
 (defn- add-zip-entry
@@ -1332,6 +1335,8 @@
   directory. Directories are included recursively and their names are
   preserved in the zip file. Currently only accepts relative paths.
 
+  Returns created `zip-file`.
+
   Options:
   * `:root` - optional directory to be elided in `zip-file` entries. E.g.: `(fs/zip [\"src\"] {:root \"src\"})`
   * `:path-fn` - an optional custom path conversion function.
@@ -1341,7 +1346,8 @@
   ([zip-file path-or-paths]
    (zip zip-file path-or-paths nil))
   ([zip-file path-or-paths opts]
-   (let [entries (if (or (string? path-or-paths)
+   (let [zip-file (as-path zip-file)
+         entries (if (or (string? path-or-paths)
                          (instance? File path-or-paths)
                          (instance? Path path-or-paths))
                    [path-or-paths]
@@ -1356,7 +1362,8 @@
                       (FileOutputStream. (file zip-file)))]
        (doseq [zpath entries]
          (copy-to-zip zos zpath #(when-not (same-file? % zip-file)
-                                   (path-fn %))))))))
+                                   (path-fn %)))))
+     zip-file)))
 
 ;;;; End zip
 

--- a/test/babashka/fs_test.clj
+++ b/test/babashka/fs_test.clj
@@ -2205,8 +2205,8 @@
 ;;
 (deftest zip-unzip-file-test
   (files "README.md")
-  (fs/zip "foo.zip" "README.md")
-  (fs/unzip "foo.zip" "out-dir")
+  (is (= "foo.zip" (str (fs/zip "foo.zip" "README.md"))))
+  (is (= "out-dir" (str (fs/unzip "foo.zip" "out-dir"))))
   (is (match? ["README.md"
                "foo.zip"
                "out-dir/README.md"]
@@ -2215,8 +2215,7 @@
   (is (thrown? FileAlreadyExistsException (fs/unzip "foo.zip" "out-dir")))
   (spit "out-dir/README.md" "content to be replaced")
   (testing "no exception when replacing-existing option specified"
-    (is (do (fs/unzip "foo.zip" "out-dir" {:replace-existing true})
-            true)))
+    (is (= "out-dir" (str (fs/unzip "foo.zip" "out-dir" {:replace-existing true})))))
   (testing (= (slurp "README.md") (slurp "out-dir/README.md"))))
 
 (deftest zip-unzip-zip-file-entry-order-test
@@ -2239,7 +2238,7 @@
                                [["foo/bar/baz/boop.txt" "boop content"]]]]]
     (util/clean-cwd)
     (create-zip-file "foo.zip" zip-entries)
-    (fs/unzip "foo.zip" ".")
+    (is (= "." (str (fs/unzip "foo.zip"))))
     (is (match? ["foo.zip"
                  "foo/bar/baz/boop.txt"]
                 (list-tree ".")) desc)))
@@ -2247,8 +2246,8 @@
 (deftest zip-unzip-dir-test
   (files "src/dira/dirb/dirc/c1.txt"
          "src/dira/a1.txt")
-  (fs/zip "foo.zip" "src")
-  (fs/unzip "foo.zip" "out-dir")
+  (is (= "foo.zip" (str (fs/zip "foo.zip" "src"))))
+  (is (= "out-dir" (str (fs/unzip "foo.zip" "out-dir"))))
   (is (match? ["out-dir/src/dira/a1.txt"
                "out-dir/src/dira/dirb/dirc/c1.txt"]
               (list-tree "out-dir"))))
@@ -2258,8 +2257,8 @@
   ;;  zip out-dir/foo.zip src README.md
   (files "README.md"
          "src/foo/bar/baz.txt")
-  (fs/zip "foo.zip" ["src" "README.md"])
-  (fs/unzip "foo.zip" "out-dir")
+  (is (= "foo.zip" (str (fs/zip "foo.zip" ["src" "README.md"]))))
+  (is (= "out-dir" (str (fs/unzip "foo.zip" "out-dir"))))
   (is (match? ["out-dir/README.md"
                "out-dir/src/foo/bar/baz.txt"]
               (list-tree "out-dir"))))
@@ -2267,8 +2266,8 @@
 (deftest zip-unzip-elide-root-parent-dir-test
   (files "src/foo/bar/baz.txt"
          "src/foo/bar/boop.txt")
-  (fs/zip "foo.zip" "src" {:root "src"})
-  (fs/unzip "foo.zip" "out-dir")
+  (is (= "foo.zip" (str (fs/zip "foo.zip" "src" {:root "src"}))))
+  (is (= "out-dir" (str (fs/unzip "foo.zip" "out-dir"))))
   (is (match? ["out-dir/foo/bar/baz.txt"
                "out-dir/foo/bar/boop.txt"]
               (list-tree "out-dir"))))
@@ -2278,8 +2277,8 @@
          "src/foo/bar/baz.clj"
          "src/foo/bar/boop.cljc"
          "src/foo/bar/bap.cljc/")
-  (fs/zip "foo.zip" ["src" "README.md"])
-  (fs/unzip "foo.zip" "out-dir" {:extract-fn #(str/ends-with? (:name %) ".clj")})
+  (is (= "foo.zip" (str (fs/zip "foo.zip" ["src" "README.md"]))))
+  (is (= "out-dir" (str (fs/unzip "foo.zip" "out-dir" {:extract-fn #(str/ends-with? (:name %) ".clj")}))))
   ;; only files that have names ending in .cljc should present
   ;; directories are not subject to extract-fn
   (is (match? ["out-dir/src/foo/bar/bap.cljc/"
@@ -2293,12 +2292,13 @@
     (fs/set-last-modified-time "README.md" readme-time)
     (fs/set-last-modified-time "LICENSE" license-time)
     (let [zip-entry-times (atom {})]
-      (fs/zip "foo.zip" ["LICENSE" "README.md"])
+      (is (= "foo.zip" (str (fs/zip "foo.zip" ["LICENSE" "README.md"]))))
       ;; record zip entry times while extracting to out-dir1
-      (fs/unzip "foo.zip" "out-dir1"
-                {:extract-fn #(let [time (.getTime ^java.util.zip.ZipEntry (:entry %))]
-                                (swap! zip-entry-times assoc (:name %) time)
-                                true)})
+      (is (= "out-dir1"
+             (str (fs/unzip "foo.zip" "out-dir1"
+                            {:extract-fn #(let [time (.getTime ^java.util.zip.ZipEntry (:entry %))]
+                                            (swap! zip-entry-times assoc (:name %) time)
+                                            true)}))))
       (is (match? {"README.md" readme-time
                    "LICENSE" license-time}
                   @zip-entry-times) "zip entry times match source file times")
@@ -2306,15 +2306,16 @@
                    "out-dir1/README.md"]
                   (list-tree "out-dir1")))
       ;; extract files to out-dir2 that have the same time as README.md
-      (fs/unzip "foo.zip" "out-dir2"
-                {:extract-fn #(= (.getTime ^java.util.zip.ZipEntry (:entry %)) readme-time)})
+      (is (= "out-dir2"
+             (str (fs/unzip "foo.zip" "out-dir2"
+                            {:extract-fn #(= (.getTime ^java.util.zip.ZipEntry (:entry %)) readme-time)}))))
       (is (match? ["out-dir2/README.md"]
                   (list-tree "out-dir2"))))))
 
 (deftest zip-should-not-zip-self-test
   (files "foo/bar/baz/somefile.txt")
-  (fs/zip "foo/zippy.zip" "foo")
-  (fs/unzip "foo/zippy.zip" "zip-out")
+  (is (= "foo/zippy.zip" (fs/unixify (fs/zip "foo/zippy.zip" "foo"))))
+  (is (= "zip-out" (str (fs/unzip "foo/zippy.zip" "zip-out"))))
   (is (match?
         ["foo/bar"
          "foo/bar/baz"
@@ -2333,9 +2334,9 @@
   (let [before (util/fsnapshot)
         ;; zip to temp-dir instead of cwd, so we don't zip our zip
         dest-zip (fs/file (fs/temp-dir) "foo.zip")]
-    (fs/zip dest-zip "" {:root ""})
+    (is (= (fs/unixify dest-zip) (fs/unixify (fs/zip dest-zip "" {:root ""}))))
     (is (thrown? java.nio.file.FileAlreadyExistsException (fs/unzip dest-zip "")))
-    (fs/unzip dest-zip "" {:replace-existing true})
+    (is (= "" (str (fs/unzip dest-zip "" {:replace-existing true}))))
     (is (match? (mapv #(update % :attr dissoc :creationTime :lastModifiedTime :lastAccessTime)
                       before)
                 (mapv #(update % :attr dissoc :creationTime :lastModifiedTime :lastAccessTime)


### PR DESCRIPTION
Step 3d for
https://github.com/babashka/fs/issues/197#issuecomment-4224723788.

`zip` now explicitly returns created `zip-file`.

`unzip` now explicitly returns `target-dir`.

Tests updated appropriately.

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/fs/blob/master/CHANGELOG.md) file with a description of the addressed issue.
