### PR TITLE
Fix `match`/`glob` dropping pattern text after a 2nd colon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ For a list of breaking changes, check [here](#breaking-changes).
 
 Babashka [fs](https://github.com/babashka/fs): file system utility library for Clojure
 
+## Unreleased
+
+- [#269](https://github.com/babashka/fs/issues/269): `match` and `glob` no longer drop pattern text after a 2nd colon on Unix
+
 ## 0.5.34 (2026-07-02)
 
 - Add Node.js support via ClojureScript and Squint support. See [Node.js docs](README.md#nodejs).

--- a/src/babashka/fs.cljc
+++ b/src/babashka/fs.cljc
@@ -640,7 +640,7 @@
   See also: [[glob]]"
   ([root-dir pattern] (match root-dir pattern nil))
   ([root-dir pattern {:keys [hidden follow-links max-depth recursive]}]
-   (let [[prefix pattern] (str/split pattern #":")
+   (let [[prefix pattern] (str/split pattern #":" 2)
          base-path (-> root-dir absolutize normalize str)
          escaped-base-path (case prefix
                              "glob" (escape-glob-chars base-path)

--- a/test/babashka/fs_test.cljc
+++ b/test/babashka/fs_test.cljc
@@ -968,6 +968,14 @@
       (files d "a" "b" "^")
       (is (= ["^" "a"] (rel-entries d (fs/glob d "[^a]")))))))
 
+(deftest glob-colon-in-pattern-test
+  (testing "a colon in the pattern is not a syntax separator"
+    (when-not (fs/windows?)
+      (fs/with-temp-dir [d]
+        (files d "a:b.txt" "other.txt")
+        (is (= ["a:b.txt"] (rel-entries d (fs/glob d "*:b.txt"))))
+        (is (= ["a:b.txt"] (rel-entries d (fs/match d "regex:.*:b\\.txt"))))))))
+
 (deftest list-dirs-test
   (fs/with-temp-dir [d]
     (files d "d1/a.clj" "d2/b.clj")


### PR DESCRIPTION
Limit the `pattern` string split to 2 parts to match that intended behaviour. Closes #269.

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/babashka/fs/blob/master/CHANGELOG.md) file with a description of the addressed issue.